### PR TITLE
Add ability to sort the walked entries

### DIFF
--- a/examples/walkdir.rs
+++ b/examples/walkdir.rs
@@ -18,6 +18,7 @@ Options:
     --max-depth NUM      Maximum depth.
     -n, --fd-max NUM     Maximum open file descriptors. [default: 32]
     --tree               Show output as a tree.
+    --sort               Sort the output.
     -q, --ignore-errors  Ignore errors.
 ";
 
@@ -31,6 +32,7 @@ struct Args {
     flag_fd_max: usize,
     flag_tree: bool,
     flag_ignore_errors: bool,
+    flag_sort: bool,
 }
 
 macro_rules! wout { ($($tt:tt)*) => { {writeln!($($tt)*)}.unwrap() } }
@@ -40,12 +42,16 @@ fn main() {
                                        .unwrap_or_else(|e| e.exit());
     let mind = args.flag_min_depth.unwrap_or(0);
     let maxd = args.flag_max_depth.unwrap_or(::std::usize::MAX);
-    let it = WalkDir::new(args.arg_dir.clone().unwrap_or(".".to_owned()))
+    let dir = args.arg_dir.clone().unwrap_or(".".to_owned());
+    let mut walkdir = WalkDir::new(dir)
                      .max_open(args.flag_fd_max)
                      .follow_links(args.flag_follow_links)
                      .min_depth(mind)
-                     .max_depth(maxd)
-                     .into_iter();
+                     .max_depth(maxd);
+    if args.flag_sort {
+        walkdir = walkdir.sort_by(|a,b| a.cmp(b));
+    }
+    let it = walkdir.into_iter();
     let mut out = io::BufWriter::new(io::stdout());
     let mut eout = io::stderr();
     if args.flag_tree {


### PR DESCRIPTION
Imagine this use-case. One wants to do a scan of all folders and perform the same scan later and obtain the list of differences.

The scanning will produce two lists that are expensive to sort. It is more efficient to have WalkDir output a sorted list.

Currently WalkDir uses the iterator from `fs::read_dir`. The entries are used as is.

The proposed patch adds a boolean value `sort` that enables sorting of the entries.
This matches nicely with the behaviour of WalkDir when `max_open == 1`: all entries of the opened dir are read instantly. in addition, they are sorted.

A simple benchmark on a directory with one million files (warm cache) shows:
```
   walkdir ~          2.0s
   walkdir --sort ~   2.8s
   walkdir ~ | sort  19.5s
```