### PR TITLE
only depend on windows deps on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 keywords = ["directory", "recursive", "walk", "iterator"]
 license = "Unlicense/MIT"
 
-[dependencies]
+[target.'cfg(windows)'.dependencies]
 kernel32-sys = "0.2"
 winapi = "0.2"
 


### PR DESCRIPTION
As far as I can tell these are only used for windows. With these changes it still builds and works on linux for me. Not tested on any other platform.