### PR TITLE
Various Windows related cleanups.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,7 @@ script:
   - cargo build --verbose
   - cargo test --verbose
   - cargo doc
+branches:
+  only:
+    - master
+    - /^\d+\.\d+\.\d+$/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ kernel32-sys = "0.2"
 winapi = "0.2"
 
 [dev-dependencies]
-docopt = "0.6"
-quickcheck = "0.2"
+docopt = "0.7"
+quickcheck = { version = "0.4", default-features = false }
 rand = "0.3"
 rustc-serialize = "0.3"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ environment:
   - TARGET: x86_64-pc-windows-msvc
   - TARGET: i686-pc-windows-msvc
   - TARGET: i686-pc-windows-gnu
+
 install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe"
   - rust-nightly-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
@@ -16,3 +17,8 @@ build: false
 test_script:
   - cargo build --verbose
   - cargo test --verbose
+
+branches:
+  only:
+    - /\d+\.\d+\.\d+/
+    - master


### PR DESCRIPTION
This modifies some of the test infrastructure so that more tests can
work on Windows. Specifically, we can now write tests that use symlinks
and still run on Windows.

We also clean up the implementation of `is_same_file` by reusing
types/functions from the kernel32 and winapi crates. Also, add a few
tests for this function.