### PR TITLE
Added html_root_url attribute

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "walkdir"
+# remember to update html_root_url
 version = "1.0.7"  #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = "Recursively walk a directory."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![doc(html_root_url = "https://docs.rs/walkdir/1.0.7")]
 /*!
 Crate `walkdir` provides an efficient and cross platform implementation
 of recursive directory traversal. Several options are exposed to control


### PR DESCRIPTION
Typically the `# remember to update html_root_url` clause is added next to the `version` field in Cargo.toml as stated in [C-HTML-ROOT](https://github.com/brson/rust-api-guidelines#crate-sets-html_root_url-attribute-c-html-root)

But I did not know if the `#:version` comment was relevant (possibly part of some uncommited script?)

I'll be glad to fix it.
fixes https://github.com/BurntSushi/walkdir/issues/33