### PR TITLE
Move DirEntry::ino method to an extension trait, Support more metadata for sort_by

### DIFF
--- a/examples/walkdir.rs
+++ b/examples/walkdir.rs
@@ -51,7 +51,7 @@ fn main() {
                      .min_depth(mind)
                      .max_depth(maxd);
     if args.flag_sort {
-        walkdir = walkdir.sort_by(|a,b| a.cmp(b));
+        walkdir = walkdir.sort_by(|(name_a, _), (name_b, _)| name_a.cmp(name_b));
     }
     if args.flag_depth {
         walkdir = walkdir.contents_first(true)

--- a/examples/walkdir.rs
+++ b/examples/walkdir.rs
@@ -51,7 +51,7 @@ fn main() {
                      .min_depth(mind)
                      .max_depth(maxd);
     if args.flag_sort {
-        walkdir = walkdir.sort_by(|(name_a, _), (name_b, _)| name_a.cmp(name_b));
+        walkdir = walkdir.sort_by(|a, b| a.file_name().cmp(b.file_name()));
     }
     if args.flag_depth {
         walkdir = walkdir.contents_first(true)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -861,15 +861,6 @@ impl DirEntry {
     }
 }
 
-#[cfg(unix)]
-impl unix::DirEntryExt for DirEntry {
-    /// Returns the underlying `d_ino` field in the contained `dirent`
-    /// structure.
-    fn ino(&self) -> u64 {
-        self.ino
-    }
-}
-
 impl Clone for DirEntry {
     #[cfg(not(unix))]
     fn clone(&self) -> DirEntry {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -191,7 +191,7 @@ struct WalkDirOptions {
     min_depth: usize,
     max_depth: usize,
     sorter: Option<Box<FnMut((&OsStr, Option<Metadata>),
-        (&OsStr, Option<Metadata>)) -> Ordering + 'static>>,
+        (&OsStr, Option<Metadata>)) -> Ordering + Send + Sync + 'static>>,
     contents_first: bool,
 }
 
@@ -308,7 +308,7 @@ impl WalkDir {
     /// ```
     pub fn sort_by<F>(mut self, cmp: F) -> Self
             where F: FnMut((&OsStr, Option<Metadata>),
-                  (&OsStr, Option<Metadata>)) -> Ordering + 'static {
+                  (&OsStr, Option<Metadata>)) -> Ordering + Send + Sync + 'static {
         self.opts.sorter = Some(Box::new(cmp));
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -776,13 +776,6 @@ impl DirEntry {
         self.depth
     }
 
-    /// Returns the underlying `d_ino` field in the contained `dirent`
-    /// structure.
-    #[cfg(unix)]
-    pub fn ino(&self) -> u64 {
-        self.ino
-    }
-
     #[cfg(not(unix))]
     fn from_entry(depth: usize, ent: &fs::DirEntry) -> Result<DirEntry> {
         let ty = try!(ent.file_type().map_err(|err| {
@@ -839,6 +832,15 @@ impl DirEntry {
             depth: depth,
             ino: md.ino(),
         })
+    }
+}
+
+#[cfg(unix)]
+impl std::os::unix::fs::DirEntryExt for DirEntry {
+    /// Returns the underlying `d_ino` field in the contained `dirent`
+    /// structure.
+    fn ino(&self) -> u64 {
+        self.ino
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -444,9 +444,9 @@ pub trait WalkDirIterator: Iterator {
     ///
     /// Note that entries skipped with `min_depth` and `max_depth` are not
     /// passed to this predicate.
-    fn filter_entry<P>(self, predicate: P) -> IterFilterEntry<Self, P>
+    fn filter_entry<P>(self, predicate: P) -> FilterEntry<Self, P>
             where Self: Sized, P: FnMut(&DirEntry) -> bool {
-        IterFilterEntry { it: self, predicate: predicate }
+        FilterEntry { it: self, predicate: predicate }
     }
 }
 
@@ -912,12 +912,12 @@ impl fmt::Debug for DirEntry {
 ///
 /// Type parameter `I` refers to the underlying iterator and `P` refers to the
 /// predicate, which is usually `FnMut(&DirEntry) -> bool`.
-pub struct IterFilterEntry<I, P> {
+pub struct FilterEntry<I, P> {
     it: I,
     predicate: P,
 }
 
-impl<I, P> Iterator for IterFilterEntry<I, P>
+impl<I, P> Iterator for FilterEntry<I, P>
         where I: WalkDirIterator<Item=Result<DirEntry>>,
               P: FnMut(&DirEntry) -> bool {
     type Item = Result<DirEntry>;
@@ -939,7 +939,7 @@ impl<I, P> Iterator for IterFilterEntry<I, P>
     }
 }
 
-impl<I, P> WalkDirIterator for IterFilterEntry<I, P>
+impl<I, P> WalkDirIterator for FilterEntry<I, P>
         where I: WalkDirIterator<Item=Result<DirEntry>>,
               P: FnMut(&DirEntry) -> bool {
     fn skip_current_dir(&mut self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -333,10 +333,10 @@ impl WalkDir {
 
 impl IntoIterator for WalkDir {
     type Item = Result<DirEntry>;
-    type IntoIter = Iter;
+    type IntoIter = IntoIter;
 
-    fn into_iter(self) -> Iter {
-        Iter {
+    fn into_iter(self) -> IntoIter {
+        IntoIter {
             opts: self.opts,
             start: Some(self.root),
             stack_list: vec![],
@@ -440,7 +440,7 @@ pub trait WalkDirIterator: Iterator {
 /// descriptors and whether the iterator should follow symbolic links.
 ///
 /// The order of elements yielded by this iterator is unspecified.
-pub struct Iter {
+pub struct IntoIter {
     /// Options specified in the builder. Depths, max fds, etc.
     opts: WalkDirOptions,
     /// The start path.
@@ -525,7 +525,7 @@ pub struct DirEntry {
     ino: u64,
 }
 
-impl Iterator for Iter {
+impl Iterator for IntoIter {
     type Item = Result<DirEntry>;
 
     fn next(&mut self) -> Option<Result<DirEntry>> {
@@ -567,7 +567,7 @@ impl Iterator for Iter {
     }
 }
 
-impl WalkDirIterator for Iter {
+impl WalkDirIterator for IntoIter {
     fn skip_current_dir(&mut self) {
         if !self.stack_list.is_empty() {
             self.stack_list.pop();
@@ -578,7 +578,7 @@ impl WalkDirIterator for Iter {
     }
 }
 
-impl Iter {
+impl IntoIter {
     fn handle_entry(
         &mut self,
         mut dent: DirEntry,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -795,7 +795,7 @@ fn walk_dir_sort_small_fd_max() {
 
 #[test]
 fn walk_dir_send_sync_traits() {
-    use IterFilterEntry;
+    use FilterEntry;
 
     fn assert_send<T: Send>() {}
     fn assert_sync<T: Sync>() {}
@@ -804,6 +804,6 @@ fn walk_dir_send_sync_traits() {
     assert_sync::<WalkDir>();
     assert_send::<IntoIter>();
     assert_sync::<IntoIter>();
-    assert_send::<IterFilterEntry<IntoIter, u8>>();
-    assert_sync::<IterFilterEntry<IntoIter, u8>>();
+    assert_send::<FilterEntry<IntoIter, u8>>();
+    assert_sync::<FilterEntry<IntoIter, u8>>();
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -761,7 +761,7 @@ fn walk_dir_sort() {
     let tmp_path = tmp.path();
     let tmp_len = tmp_path.to_str().unwrap().len();
     exp.create_in(tmp_path).unwrap();
-    let it = WalkDir::new(tmp_path).sort_by(|a,b| a.0.cmp(b.0)).into_iter();
+    let it = WalkDir::new(tmp_path).sort_by(|a,b| a.file_name().cmp(b.file_name())).into_iter();
     let got = it.map(|d| {
         let path = d.unwrap();
         let path = &path.path().to_str().unwrap()[tmp_len..];
@@ -783,7 +783,7 @@ fn walk_dir_sort_small_fd_max() {
     let tmp_len = tmp_path.to_str().unwrap().len();
     exp.create_in(tmp_path).unwrap();
     let it =
-        WalkDir::new(tmp_path).max_open(1).sort_by(|a,b| a.0.cmp(b.0)).into_iter();
+        WalkDir::new(tmp_path).max_open(1).sort_by(|a,b| a.file_name().cmp(b.file_name())).into_iter();
     let got = it.map(|d| {
         let path = d.unwrap();
         let path = &path.path().to_str().unwrap()[tmp_len..];

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -792,3 +792,18 @@ fn walk_dir_sort_small_fd_max() {
     assert_eq!(got,
         ["", "/foo", "/foo/abc", "/foo/abc/fit", "/foo/bar", "/foo/faz"]);
 }
+
+#[test]
+fn walk_dir_send_sync_traits() {
+    use IterFilterEntry;
+
+    fn assert_send<T: Send>() {}
+    fn assert_sync<T: Sync>() {}
+
+    assert_send::<WalkDir>();
+    assert_sync::<WalkDir>();
+    assert_send::<Iter>();
+    assert_sync::<Iter>();
+    assert_send::<IterFilterEntry<Iter, u8>>();
+    assert_sync::<IterFilterEntry<Iter, u8>>();
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 use quickcheck::{Arbitrary, Gen, QuickCheck, StdGen};
 use rand::{self, Rng};
 
-use super::{DirEntry, WalkDir, WalkDirIterator, Iter, Error, ErrorInner};
+use super::{DirEntry, WalkDir, WalkDirIterator, IntoIter, Error, ErrorInner};
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 enum Tree {
@@ -272,7 +272,7 @@ enum WalkEvent {
 
 struct WalkEventIter {
     depth: usize,
-    it: Iter,
+    it: IntoIter,
     next: Option<Result<DirEntry, Error>>,
 }
 
@@ -802,8 +802,8 @@ fn walk_dir_send_sync_traits() {
 
     assert_send::<WalkDir>();
     assert_sync::<WalkDir>();
-    assert_send::<Iter>();
-    assert_sync::<Iter>();
-    assert_send::<IterFilterEntry<Iter, u8>>();
-    assert_sync::<IterFilterEntry<Iter, u8>>();
+    assert_send::<IntoIter>();
+    assert_sync::<IntoIter>();
+    assert_send::<IterFilterEntry<IntoIter, u8>>();
+    assert_sync::<IterFilterEntry<IntoIter, u8>>();
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -761,7 +761,7 @@ fn walk_dir_sort() {
     let tmp_path = tmp.path();
     let tmp_len = tmp_path.to_str().unwrap().len();
     exp.create_in(tmp_path).unwrap();
-    let it = WalkDir::new(tmp_path).sort_by(|a,b| a.cmp(b)).into_iter();
+    let it = WalkDir::new(tmp_path).sort_by(|a,b| a.0.cmp(b.0)).into_iter();
     let got = it.map(|d| {
         let path = d.unwrap();
         let path = &path.path().to_str().unwrap()[tmp_len..];
@@ -783,7 +783,7 @@ fn walk_dir_sort_small_fd_max() {
     let tmp_len = tmp_path.to_str().unwrap().len();
     exp.create_in(tmp_path).unwrap();
     let it =
-        WalkDir::new(tmp_path).max_open(1).sort_by(|a,b| a.cmp(b)).into_iter();
+        WalkDir::new(tmp_path).max_open(1).sort_by(|a,b| a.0.cmp(b.0)).into_iter();
     let got = it.map(|d| {
         let path = d.unwrap();
         let path = &path.path().to_str().unwrap()[tmp_len..];

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,8 +1,16 @@
 
-/// Unix specific extension methods.
-pub trait DirEntryExt {
+use DirEntry;
 
-    /// Returns an inode.
+/// Unix-specific extension methods for `walkdir::DirEntry`
+pub trait DirEntryExt {
+    /// Returns the underlying `d_ino` field in the contained `dirent` structure.
     fn ino(&self) -> u64;
 }
 
+impl DirEntryExt for DirEntry {
+    /// Returns the underlying `d_ino` field in the contained `dirent`
+    /// structure.
+    fn ino(&self) -> u64 {
+        self.ino
+    }
+}

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -8,8 +8,6 @@ pub trait DirEntryExt {
 }
 
 impl DirEntryExt for DirEntry {
-    /// Returns the underlying `d_ino` field in the contained `dirent`
-    /// structure.
     fn ino(&self) -> u64 {
         self.ino
     }

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,0 +1,8 @@
+
+/// Unix specific extension methods.
+pub trait DirEntryExt {
+
+    /// Returns an inode.
+    fn ino(&self) -> u64;
+}
+


### PR DESCRIPTION
Is it right to break the api when making improvements ? If so, do I need to change the version number ?