### PR TITLE
Add badges for travis-ci and appveyor to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ readme = "README.md"
 keywords = ["directory", "recursive", "walk", "iterator"]
 license = "Unlicense/MIT"
 
+[badges]
+travis-ci = { repository = "BurntSushi/walkdir" }
+appveyor = { repository = "BurntSushi/walkdir" }
+
 [dependencies]
 same-file = "0.1.1"
 


### PR DESCRIPTION
Fixes #35

Doesn't add CI for OSX