### PR TITLE
Bumped the minimal required rust version to 1.16.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.10.0
+  - 1.16.0
   - stable
   - beta
   - nightly


### PR DESCRIPTION
as mentioned in https://github.com/BurntSushi/walkdir/pull/52#issuecomment-311210665 the next backwards supported rust version is to be 1.16.0.

fixes https://github.com/BurntSushi/walkdir/issues/61

