### PR TITLE
WalkDir sorter should accept whole dir entries instead of just file names

### DIFF
--- a/examples/walkdir.rs
+++ b/examples/walkdir.rs
@@ -51,7 +51,7 @@ fn main() {
                      .min_depth(mind)
                      .max_depth(maxd);
     if args.flag_sort {
-        walkdir = walkdir.sort_by(|a,b| a.cmp(b));
+        walkdir = walkdir.sort_by(|a,b| a.file_name().cmp(b.file_name()));
     }
     if args.flag_depth {
         walkdir = walkdir.contents_first(true)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,7 +230,7 @@ struct WalkDirOptions {
     max_open: usize,
     min_depth: usize,
     max_depth: usize,
-    sorter: Option<Box<FnMut(&OsString,&OsString) -> Ordering + 'static>>,
+    sorter: Option<Box<FnMut(&DirEntry,&DirEntry) -> Ordering + 'static>>,
     contents_first: bool,
 }
 
@@ -337,10 +337,10 @@ impl WalkDir {
     /// use std::ffi::OsString;
     /// use walkdir::WalkDir;
     ///
-    /// WalkDir::new("foo").sort_by(|a,b| a.cmp(b));
+    /// WalkDir::new("foo").sort_by(|a,b| a.file_name().cmp(b.file_name()));
     /// ```
     pub fn sort_by<F>(mut self, cmp: F) -> Self
-            where F: FnMut(&OsString, &OsString) -> Ordering + 'static {
+            where F: FnMut(&DirEntry, &DirEntry) -> Ordering + 'static {
         self.opts.sorter = Some(Box::new(cmp));
         self
     }
@@ -488,7 +488,7 @@ enum DirList {
     /// A closed handle.
     ///
     /// All remaining directory entries are read into memory.
-    Closed(vec::IntoIter<Result<fs::DirEntry>>),
+    Closed(vec::IntoIter<Result<DirEntry>>),
 }
 
 /// A directory entry.
@@ -553,7 +553,6 @@ impl Iterator for IntoIter {
                 None => self.pop(),
                 Some(Err(err)) => return Some(Err(err)),
                 Some(Ok(dent)) => {
-                    let dent = itry!(DirEntry::from_entry(self.depth, &dent));
                     if let Some(result) = self.handle_entry(dent) {
                         return Some(result);
                     }
@@ -713,7 +712,7 @@ impl IntoIter {
             entries.sort_by(|a, b| {
                 match (a, b) {
                     (&Ok(ref a), &Ok(ref b)) => {
-                        cmp(&a.file_name(), &b.file_name())
+                        cmp(a, b)
                     }
                     (&Err(_), &Err(_)) => Ordering::Equal,
                     (&Ok(_), &Err(_)) => Ordering::Greater,
@@ -783,17 +782,18 @@ impl DirList {
 }
 
 impl Iterator for DirList {
-    type Item = Result<fs::DirEntry>;
+    type Item = Result<DirEntry>;
 
     #[inline(always)]
-    fn next(&mut self) -> Option<Result<fs::DirEntry>> {
+    fn next(&mut self) -> Option<Result<DirEntry>> {
         match *self {
             DirList::Closed(ref mut it) => it.next(),
             DirList::Opened { depth, ref mut it } => match *it {
                 Err(ref mut err) => err.take().map(Err),
-                Ok(ref mut rd) => rd.next().map(|r| r.map_err(|err| {
-                    Error::from_io(depth + 1, err)
-                })),
+                Ok(ref mut rd) => rd.next().map(|r| match r {
+                    Ok(r) => DirEntry::from_entry(depth + 1, &r),
+                    Err(err) => Err(Error::from_io(depth + 1, err))
+                }),
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,8 +329,7 @@ impl WalkDir {
     ///
     /// If a compare function is set, the resulting iterator will return all
     /// paths in sorted order. The compare function will be called to compare
-    /// names from entries from the same directory using only the name of the
-    /// entry.
+    /// entries from the same directory.
     ///
     /// ```rust,no-run
     /// use std::cmp;
@@ -402,15 +401,10 @@ impl WalkDir {
     /// // def
     /// // foo
     /// ```
-
-
-
     pub fn contents_first(mut self, yes: bool) -> Self {
         self.opts.contents_first = yes;
         self
     }
-
-
 }
 
 impl IntoIterator for WalkDir {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -761,7 +761,7 @@ fn walk_dir_sort() {
     let tmp_path = tmp.path();
     let tmp_len = tmp_path.to_str().unwrap().len();
     exp.create_in(tmp_path).unwrap();
-    let it = WalkDir::new(tmp_path).sort_by(|a,b| a.cmp(b)).into_iter();
+    let it = WalkDir::new(tmp_path).sort_by(|a,b| a.file_name().cmp(b.file_name())).into_iter();
     let got = it.map(|d| {
         let path = d.unwrap();
         let path = &path.path().to_str().unwrap()[tmp_len..];
@@ -783,7 +783,7 @@ fn walk_dir_sort_small_fd_max() {
     let tmp_len = tmp_path.to_str().unwrap().len();
     exp.create_in(tmp_path).unwrap();
     let it =
-        WalkDir::new(tmp_path).max_open(1).sort_by(|a,b| a.cmp(b)).into_iter();
+        WalkDir::new(tmp_path).max_open(1).sort_by(|a,b| a.file_name().cmp(b.file_name())).into_iter();
     let got = it.map(|d| {
         let path = d.unwrap();
         let path = &path.path().to_str().unwrap()[tmp_len..];


### PR DESCRIPTION
Currently it is not easy to sort entries alphabetically with directories first (which is most often the order in which we see files in tools), since sorter for `WalkDir::sort_by()` only provides file names. In this PR I have changed the code, so that the sorter accepts references to entries being sorted. Example usage:
```
extern crate walkdir;

fn main() {
    use std::cmp::Ordering;
    use walkdir::WalkDir;

    // Paths sorted alphabetically with directories first
    for e in WalkDir::new("./").sort_by(|a, b| match b.file_type().is_dir().cmp(&a.file_type().is_dir()) {
        Ordering::Equal => a.file_name().cmp(b.file_name()),
        o @ _ => o,
    }).into_iter().filter_map(|e| e.ok()) {
        println!("{}", e.path().display());
    }
}
```
If this change would to be accepted, we have to also fix the documentation accordingly.
Regards