### PR TITLE
Add osx build to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ rust:
   - stable
   - beta
   - nightly
+os:
+  - linux
+  - osx
 script:
   - cargo build --verbose
   - cargo test --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 language: rust
-rust:
-  - 1.16.0
-  - stable
-  - beta
-  - nightly
-os:
-  - linux
-  - osx
+matrix:
+  include:
+    - os: linux
+      rust: 1.16.0
+    - os: linux
+      rust: stable
+    - os: linux
+      rust: beta
+    - os: linux
+      rust: beta
+    - os: osx
+      rust: nightly
 script:
   - cargo build --verbose
   - cargo test --verbose


### PR DESCRIPTION
In response to https://github.com/BurntSushi/walkdir/pull/60#issuecomment-311212136.

I think that testing a cross-platform lib on all main platforms makes sense for the libz blitz.