### PR TITLE
Unix-specific Extension trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,6 +133,7 @@ use std::vec;
 
 use same_file::is_same_file;
 
+#[cfg(unix)] mod unix;
 #[cfg(test)] mod tests;
 
 /// Like try, but for iterators that return [`Option<Result<_, _>>`].
@@ -1019,15 +1020,6 @@ impl DirEntry {
             depth: depth,
             ino: md.ino(),
         })
-    }
-}
-
-#[cfg(unix)]
-impl std::os::unix::fs::DirEntryExt for DirEntry {
-    /// Returns the underlying `d_ino` field in the contained `dirent`
-    /// structure.
-    fn ino(&self) -> u64 {
-        self.ino
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -963,13 +963,6 @@ impl DirEntry {
         self.depth
     }
 
-    /// Returns the underlying `d_ino` field in the contained `dirent`
-    /// structure.
-    #[cfg(unix)]
-    pub fn ino(&self) -> u64 {
-        self.ino
-    }
-
     #[cfg(not(unix))]
     fn from_entry(depth: usize, ent: &fs::DirEntry) -> Result<DirEntry> {
         let ty = try!(ent.file_type().map_err(|err| {
@@ -1026,6 +1019,15 @@ impl DirEntry {
             depth: depth,
             ino: md.ino(),
         })
+    }
+}
+
+#[cfg(unix)]
+impl std::os::unix::fs::DirEntryExt for DirEntry {
+    /// Returns the underlying `d_ino` field in the contained `dirent`
+    /// structure.
+    fn ino(&self) -> u64 {
+        self.ino
     }
 }
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -1,0 +1,15 @@
+use DirEntry;
+
+/// Unix-specific extension methods for `walkdir::DirEntry`
+pub trait DirEntryExt {
+    /// Returns the underlying `d_ino` field in the contained `dirent` structure.
+    fn ino(&self) -> u64;
+}
+
+impl DirEntryExt for DirEntry {
+    /// Returns the underlying `d_ino` field in the contained `dirent`
+    /// structure.
+    fn ino(&self) -> u64 {
+        self.ino
+    }
+}


### PR DESCRIPTION
Closes #46

Cherry pick from #53

I've made the following changes to @jeremielate's origin commits:

- Ensure the `unix` module is `use`d