### PR TITLE
Duplicate rust beta being run, should be nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - os: linux
       rust: beta
     - os: linux
-      rust: beta
+      rust: nightly
     - os: osx
       rust: nightly
 script:


### PR DESCRIPTION
Two linux builds using rust beta are being run on Travis.
Nightly isn't being tested.