### PR TITLE
towards 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: rust
 matrix:
   include:
     - os: linux
-      rust: 1.16.0
+      rust: 1.17.0
     - os: linux
       rust: stable
     - os: linux

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ travis-ci = { repository = "BurntSushi/walkdir" }
 appveyor = { repository = "BurntSushi/walkdir" }
 
 [dependencies]
-same-file = "0.1.1"
+same-file = "1"
 
 [target.'cfg(windows)'.dependencies]
 kernel32-sys = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "walkdir"
 # remember to update html_root_url
-version = "1.0.7"  #:version
+version = "2.0.0"  #:version
 authors = ["Andrew Gallant <jamslam@gmail.com>"]
 description = "Recursively walk a directory."
 documentation = "https://docs.rs/walkdir/"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,8 @@ kernel32-sys = "0.2"
 winapi = "0.2"
 
 [dev-dependencies]
-docopt = "0.7"
+docopt = "0.8"
 quickcheck = { version = "0.4", default-features = false }
 rand = "0.3"
-rustc-serialize = "0.3"
+serde = "1"
+serde_derive = "1"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To use this crate, add `walkdir` as a dependency to your project's
 
 ```
 [dependencies]
-walkdir = "1"
+walkdir = "2"
 ```
 
 ### Example

--- a/examples/walkdir.rs
+++ b/examples/walkdir.rs
@@ -1,5 +1,7 @@
 extern crate docopt;
-extern crate rustc_serialize;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
 extern crate walkdir;
 
 use std::io::{self, Write};
@@ -23,7 +25,7 @@ Options:
     -d, --depth          Show directory's contents before the directory itself.
 ";
 
-#[derive(Debug, RustcDecodable)]
+#[derive(Debug, Deserialize)]
 #[allow(dead_code)]
 struct Args {
     arg_dir: Option<String>,
@@ -40,8 +42,9 @@ struct Args {
 macro_rules! wout { ($($tt:tt)*) => { {writeln!($($tt)*)}.unwrap() } }
 
 fn main() {
-    let args: Args = Docopt::new(USAGE).and_then(|d| d.decode())
-                                       .unwrap_or_else(|e| e.exit());
+    let args: Args = Docopt::new(USAGE)
+        .and_then(|d| d.deserialize())
+        .unwrap_or_else(|e| e.exit());
     let mind = args.flag_min_depth.unwrap_or(0);
     let maxd = args.flag_max_depth.unwrap_or(::std::usize::MAX);
     let dir = args.arg_dir.clone().unwrap_or(".".to_owned());

--- a/examples/walkdir.rs
+++ b/examples/walkdir.rs
@@ -49,10 +49,10 @@ fn main() {
     let maxd = args.flag_max_depth.unwrap_or(::std::usize::MAX);
     let dir = args.arg_dir.clone().unwrap_or(".".to_owned());
     let mut walkdir = WalkDir::new(dir)
-                     .max_open(args.flag_fd_max)
-                     .follow_links(args.flag_follow_links)
-                     .min_depth(mind)
-                     .max_depth(maxd);
+        .max_open(args.flag_fd_max)
+        .follow_links(args.flag_follow_links)
+        .min_depth(mind)
+        .max_depth(maxd);
     if args.flag_sort {
         walkdir = walkdir.sort_by(|a,b| a.file_name().cmp(b.file_name()));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ To use this crate, add `walkdir` as a dependency to your project's
 
 ```text
 [dependencies]
-walkdir = "1"
+walkdir = "2"
 ```
 
 # From the top
@@ -103,7 +103,7 @@ for entry in walker.filter_entry(|e| !is_hidden(e)) {
 [`filter_entry`]: struct.IntoIter.html#method.filter_entry
 */
 
-#![doc(html_root_url = "https://docs.rs/walkdir/1.0.7")]
+#![doc(html_root_url = "https://docs.rs/walkdir/2.0.0")]
 #![deny(missing_docs)]
 
 #[cfg(windows)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![doc(html_root_url = "https://docs.rs/walkdir/1.0.7")]
 /*!
 Crate `walkdir` provides an efficient and cross platform implementation
 of recursive directory traversal. Several options are exposed to control
@@ -102,6 +101,10 @@ for entry in walker.filter_entry(|e| !is_hidden(e)) {
 
 [`filter_entry`]: struct.IntoIter.html#method.filter_entry
 */
+
+#![doc(html_root_url = "https://docs.rs/walkdir/1.0.7")]
+#![deny(missing_docs)]
+
 #[cfg(windows)] extern crate kernel32;
 #[cfg(windows)] extern crate winapi;
 #[cfg(test)] extern crate quickcheck;
@@ -856,12 +859,12 @@ impl DirEntry {
     ///
     /// Note that this *always* returns the path reported by the underlying
     /// directory entry, even when symbolic links are followed. To get the
-    /// target path, use [`path_is_symbolic_link`] to (cheaply) check if
+    /// target path, use [`path_is_symlink`] to (cheaply) check if
     /// this entry corresponds to a symbolic link, and [`std::fs::read_link`] to
     /// resolve the target.
     ///
     /// [`WalkDir::new`]: struct.WalkDir.html#method.new
-    /// [`path_is_symbolic_link`]: struct.DirEntry.html#method.path_is_symbolic_link
+    /// [`path_is_symlink`]: struct.DirEntry.html#method.path_is_symlink
     /// [`std::fs::read_link`]: https://doc.rust-lang.org/stable/std/fs/fn.read_link.html
     pub fn path(&self) -> &Path {
         &self.path
@@ -877,7 +880,7 @@ impl DirEntry {
     /// [`path`]: struct.DirEntry.html#method.path
     /// [`follow_links`]: struct.WalkDir.html#method.follow_links
     /// [`std::fs::read_link(entry.path())`]: https://doc.rust-lang.org/stable/std/fs/fn.read_link.html
-    pub fn path_is_symbolic_link(&self) -> bool {
+    pub fn path_is_symlink(&self) -> bool {
         self.ty.is_symlink() || self.follow_link
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -821,22 +821,21 @@ impl IntoIter {
     }
 
     fn follow(&self, mut dent: DirEntry) -> Result<DirEntry> {
-        dent = try!(DirEntry::from_link(self.depth,
-                                        dent.path().to_path_buf()));
+        dent = DirEntry::from_link(self.depth, dent.path().to_path_buf())?;
         // The only way a symlink can cause a loop is if it points
         // to a directory. Otherwise, it always points to a leaf
         // and we can omit any loop checks.
         if dent.file_type().is_dir() {
-            try!(self.check_loop(dent.path()));
+            self.check_loop(dent.path())?;
         }
         Ok(dent)
     }
 
     fn check_loop<P: AsRef<Path>>(&self, child: P) -> Result<()> {
         for ancestor in self.stack_path.iter().rev() {
-            let same = try!(is_same_file(ancestor, &child).map_err(|err| {
+            let same = is_same_file(ancestor, &child).map_err(|err| {
                 Error::from_io(self.depth, err)
-            }));
+            })?;
             if same {
                 return Err(Error {
                     depth: self.depth,
@@ -976,9 +975,9 @@ impl DirEntry {
 
     #[cfg(not(unix))]
     fn from_entry(depth: usize, ent: &fs::DirEntry) -> Result<DirEntry> {
-        let ty = try!(ent.file_type().map_err(|err| {
+        let ty = ent.file_type().map_err(|err| {
             Error::from_path(depth, ent.path(), err)
-        }));
+        })?;
         Ok(DirEntry {
             path: ent.path(),
             ty: ty,
@@ -991,9 +990,9 @@ impl DirEntry {
     fn from_entry(depth: usize, ent: &fs::DirEntry) -> Result<DirEntry> {
         use std::os::unix::fs::DirEntryExt;
 
-        let ty = try!(ent.file_type().map_err(|err| {
+        let ty = ent.file_type().map_err(|err| {
             Error::from_path(depth, ent.path(), err)
-        }));
+        })?;
         Ok(DirEntry {
             path: ent.path(),
             ty: ty,
@@ -1005,9 +1004,9 @@ impl DirEntry {
 
     #[cfg(not(unix))]
     fn from_link(depth: usize, pb: PathBuf) -> Result<DirEntry> {
-        let md = try!(fs::metadata(&pb).map_err(|err| {
+        let md = fs::metadata(&pb).map_err(|err| {
             Error::from_path(depth, pb.clone(), err)
-        }));
+        })?;
         Ok(DirEntry {
             path: pb,
             ty: md.file_type(),
@@ -1020,9 +1019,9 @@ impl DirEntry {
     fn from_link(depth: usize, pb: PathBuf) -> Result<DirEntry> {
         use std::os::unix::fs::MetadataExt;
 
-        let md = try!(fs::metadata(&pb).map_err(|err| {
+        let md = fs::metadata(&pb).map_err(|err| {
             Error::from_path(depth, pb.clone(), err)
-        }));
+        })?;
         Ok(DirEntry {
             path: pb,
             ty: md.file_type(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,16 +164,17 @@ pub type Result<T> = ::std::result::Result<T, Error>;
 /// A builder to create an iterator for recursively walking a directory.
 ///
 /// Results are returned in depth first fashion, with directories yielded
-///before their contents. If [`contents_first`] is true, contents are yielded
-///before their directories. The order is unspecified but if [`sort_by`] is
-///given, directory entries are sorted according to this function. Directory
-///entries `.` and `..` are always omitted.
+/// before their contents. If [`contents_first`] is true, contents are yielded
+/// before their directories. The order is unspecified but if [`sort_by`] is
+/// given, directory entries are sorted according to this function. Directory
+/// entries `.` and `..` are always omitted.
 ///
 /// If an error occurs at any point during iteration, then it is returned in
 /// place of its corresponding directory entry and iteration continues as
-/// normal. If an error occurs while opening a directory for reading, it
-/// is skipped. Iteration may be stopped at any time. When the iterator is
-/// destroyed, all resources associated with it are freed.
+/// normal. If an error occurs while opening a directory for reading, then it
+/// is not descended into (but the error is still yielded by the iterator).
+/// Iteration may be stopped at any time. When the iterator is destroyed, all
+/// resources associated with it are freed.
 ///
 /// [`contents_first`]: struct.WalkDir.html#method.contents_first
 /// [`sort_by`]: struct.WalkDir.html#method.sort_by
@@ -543,7 +544,10 @@ enum DirList {
 /// This is the type of value that is yielded from the iterators defined in
 /// this crate.
 ///
-/// # Differences with [`std::fs::DirEntry`]
+/// On Unix systems, this type implements the [`DirEntryExt`] trait, which
+/// provides efficient access to the inode number of the directory entry.
+///
+/// # Differences with `std::fs::DirEntry`
 ///
 /// This type mostly mirrors the type by the same name in [`std::fs`]. There
 /// are some differences however:
@@ -556,11 +560,11 @@ enum DirList {
 /// operations except for [`path`] operate on the link target. Otherwise, all
 /// operations operate on the symbolic link.
 ///
-/// [`std::fs::DirEntry`]: https://doc.rust-lang.org/stable/std/fs/struct.DirEntry.html
 /// [`std::fs`]: https://doc.rust-lang.org/stable/std/fs/index.html
 /// [`path`]: #method.path
 /// [`file_name`]: #method.file_name
 /// [`follow_links`]: struct.WalkDir.html#method.follow_links
+/// [`DirEntryExt`]: trait.DirEntryExt.html
 pub struct DirEntry {
     /// The path as reported by the [`fs::ReadDir`] iterator (even if it's a
     /// symbolic link).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,8 +128,13 @@ use std::vec;
 
 use same_file::is_same_file;
 
-#[cfg(unix)] mod unix;
-#[cfg(test)] mod tests;
+#[cfg(unix)]
+pub use unix::DirEntryExt;
+
+#[cfg(test)]
+mod tests;
+#[cfg(unix)]
+mod unix;
 
 /// Like try, but for iterators that return [`Option<Result<_, _>>`].
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,10 +15,10 @@ walkdir = "1"
 
 # From the top
 
-The [`WalkDir`] type builds iterators. The [`DirEntry`] type describes values yielded by the iterator.
-Finally, the [`Error`] type is a small wrapper around [`std::io::Error`] with
-additional information, such as if a loop was detected while following symbolic
-links (not enabled by default).
+The [`WalkDir`] type builds iterators. The [`DirEntry`] type describes values
+yielded by the iterator. Finally, the [`Error`] type is a small wrapper around
+[`std::io::Error`] with additional information, such as if a loop was detected
+while following symbolic links (not enabled by default).
 
 [`WalkDir`]: struct.Walkdir.html
 [`DirEntry`]: struct.DirEntry.html
@@ -42,9 +42,10 @@ for entry in WalkDir::new("foo") {
 # }
 ```
 
-Or, if you'd like to iterate over all entries and ignore any errors that may
-arise, use [`filter_map`]. (e.g., This code below will silently skip directories
-that the owner of the running process does not have permission to access.)
+Or, if you'd like to iterate over all entries and ignore any errors that
+may arise, use [`filter_map`]. (e.g., This code below will silently skip
+directories that the owner of the running process does not have permission to
+access.)
 
 ```no_run
 use walkdir::WalkDir;
@@ -105,11 +106,15 @@ for entry in walker.filter_entry(|e| !is_hidden(e)) {
 #![doc(html_root_url = "https://docs.rs/walkdir/1.0.7")]
 #![deny(missing_docs)]
 
-#[cfg(windows)] extern crate kernel32;
-#[cfg(windows)] extern crate winapi;
-#[cfg(test)] extern crate quickcheck;
-#[cfg(test)] extern crate rand;
+#[cfg(windows)]
+extern crate kernel32;
+#[cfg(test)]
+extern crate quickcheck;
+#[cfg(test)]
+extern crate rand;
 extern crate same_file;
+#[cfg(windows)]
+extern crate winapi;
 
 use std::cmp::{Ordering, min};
 use std::error;
@@ -154,10 +159,10 @@ pub type Result<T> = ::std::result::Result<T, Error>;
 /// A builder to create an iterator for recursively walking a directory.
 ///
 /// Results are returned in depth first fashion, with directories yielded
-/// before their contents. If [`contents_first`] is true, contents are yielded
-/// before their directories. The order is unspecified but if [`sort_by`] is given,
-/// directory entries are sorted according to this function. Directory entries
-///`.` and `..` are always omitted.
+///before their contents. If [`contents_first`] is true, contents are yielded
+///before their directories. The order is unspecified but if [`sort_by`] is
+///given, directory entries are sorted according to this function. Directory
+///entries `.` and `..` are always omitted.
 ///
 /// If an error occurs at any point during iteration, then it is returned in
 /// place of its corresponding directory entry and iteration continues as
@@ -175,8 +180,8 @@ pub type Result<T> = ::std::result::Result<T, Error>;
 /// to use iterator adapters such as [`filter_entry`].
 ///
 /// Idiomatic use of this type should use method chaining to set desired
-/// options. For example, this only shows entries with a depth of `1`, `2`
-/// or `3` (relative to `foo`):
+/// options. For example, this only shows entries with a depth of `1`, `2` or
+/// `3` (relative to `foo`):
 ///
 /// ```no_run
 /// use walkdir::WalkDir;
@@ -235,12 +240,14 @@ struct WalkDirOptions {
     max_open: usize,
     min_depth: usize,
     max_depth: usize,
-    sorter: Option<Box<FnMut(&DirEntry,&DirEntry) -> Ordering + Send + Sync + 'static>>,
+    sorter: Option<Box<
+        FnMut(&DirEntry,&DirEntry) -> Ordering + Send + Sync + 'static
+    >>,
     contents_first: bool,
 }
 
 impl fmt::Debug for WalkDirOptions {
-    fn fmt(&self, f: &mut fmt::Formatter) -> ::std::result::Result<(), fmt::Error> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> result::Result<(), fmt::Error> {
         let sorter_str = if self.sorter.is_some() {
             // FnMut isn't `Debug`
             "Some(...)"
@@ -365,7 +372,8 @@ impl WalkDir {
     /// WalkDir::new("foo").sort_by(|a,b| a.file_name().cmp(b.file_name()));
     /// ```
     pub fn sort_by<F>(mut self, cmp: F) -> Self
-            where F: FnMut(&DirEntry, &DirEntry) -> Ordering + Send + Sync + 'static {
+    where F: FnMut(&DirEntry, &DirEntry) -> Ordering + Send + Sync + 'static
+    {
         self.opts.sorter = Some(Box::new(cmp));
         self
     }
@@ -393,8 +401,8 @@ impl WalkDir {
     ///   def/
     /// ```
     ///
-    /// With contents_first disabled (the default), the following code visits the
-    /// directory tree in depth-first order:
+    /// With contents_first disabled (the default), the following code visits
+    /// the directory tree in depth-first order:
     ///
     /// ```no_run
     /// use walkdir::WalkDir;
@@ -454,8 +462,8 @@ impl IntoIterator for WalkDir {
 ///
 /// A value with this type must be constructed with the [`WalkDir`] type, which
 /// uses a builder pattern to set options such as min/max depth, max open file
-/// descriptors and whether the iterator should follow symbolic links.  After constructing
-/// a `WalkDir`, call [`.into_iter()`] at the end of the chain.
+/// descriptors and whether the iterator should follow symbolic links. After
+/// constructing a `WalkDir`, call [`.into_iter()`] at the end of the chain.
 ///
 /// The order of elements yielded by this iterator is unspecified.
 ///
@@ -478,15 +486,15 @@ pub struct IntoIter {
     stack_list: Vec<DirList>,
     /// A stack of file paths.
     ///
-    /// This is *only* used when [`follow_links`] is enabled. In all other cases
-    /// this stack is empty.
+    /// This is *only* used when [`follow_links`] is enabled. In all other
+    /// cases this stack is empty.
     ///
     /// [`follow_links`]: struct.WalkDir.html#method.follow_links
     stack_path: Vec<PathBuf>,
     /// An index into `stack_list` that points to the oldest open directory
-    /// handle. If the maximum fd limit is reached and a new directory needs
-    /// to be read, the handle at this index is closed before the new directory
-    /// is opened.
+    /// handle. If the maximum fd limit is reached and a new directory needs to
+    /// be read, the handle at this index is closed before the new directory is
+    /// opened.
     oldest_opened: usize,
     /// The current depth of iteration (the length of the stack at the
     /// beginning of each iteration).
@@ -512,8 +520,8 @@ enum DirList {
     ///
     /// This includes the depth of the handle itself.
     ///
-    /// If there was an error with the initial [`fs::read_dir`] call, then it is
-    /// stored here. (We use an [`Option<...>`] to make yielding the error
+    /// If there was an error with the initial [`fs::read_dir`] call, then it
+    /// is stored here. (We use an [`Option<...>`] to make yielding the error
     /// exactly once simpler.)
     ///
     /// [`fs::read_dir`]: https://doc.rust-lang.org/stable/std/fs/fn.read_dir.html
@@ -532,8 +540,8 @@ enum DirList {
 ///
 /// # Differences with [`std::fs::DirEntry`]
 ///
-/// This type mostly mirrors the type by the same name in [`std::fs`]. There are
-/// some differences however:
+/// This type mostly mirrors the type by the same name in [`std::fs`]. There
+/// are some differences however:
 ///
 /// * All recursive directory iterators must inspect the entry's type.
 /// Therefore, the value is stored and its access is guaranteed to be cheap and
@@ -572,8 +580,8 @@ impl Iterator for IntoIter {
     ///
     /// # Errors
     ///
-    /// If the iterator fails to retrieve the next value, this method returns an error value.
-    /// The error will be wrapped in an Option::Some.
+    /// If the iterator fails to retrieve the next value, this method returns
+    /// an error value. The error will be wrapped in an Option::Some.
     fn next(&mut self) -> Option<Result<DirEntry>> {
         if let Some(start) = self.start.take() {
             let dent = itry!(DirEntry::from_link(0, start));
@@ -592,8 +600,9 @@ impl Iterator for IntoIter {
                 self.pop();
                 continue;
             }
-            // Unwrap is safe here because we've verified above that `self.stack_list` is not empty
-            match self.stack_list.last_mut().expect("This is a bug in walkdir").next() {
+            // Unwrap is safe here because we've verified above that
+            // `self.stack_list` is not empty
+            match self.stack_list.last_mut().expect("bug in walkdir").next() {
                 None => self.pop(),
                 Some(Err(err)) => return Some(Err(err)),
                 Some(Ok(dent)) => {
@@ -704,11 +713,17 @@ impl IntoIter {
     /// Note that entries skipped with [`min_depth`] and [`max_depth`] are not
     /// passed to this predicate.
     ///
+    /// Note that if the iterator has `contents_first` enabled, then this
+    /// method is no different than calling the standard `Iterator::filter`
+    /// method (because directory entries are yielded after they've been
+    /// descended into).
+    ///
     /// [`skip_current_dir`]: #method.skip_current_dir
     /// [`min_depth`]: struct.WalkDir.html#method.min_depth
     /// [`max_depth`]: struct.WalkDir.html#method.max_depth
     pub fn filter_entry<P>(self, predicate: P) -> FilterEntry<Self, P>
-            where Self: Sized, P: FnMut(&DirEntry) -> bool {
+    where P: FnMut(&DirEntry) -> bool
+    {
         FilterEntry { it: self, predicate: predicate }
     }
 
@@ -725,8 +740,10 @@ impl IntoIter {
         if dent.file_type().is_dir() && self.opts.contents_first {
             self.deferred_dirs.push(dent);
             None
+        } else if self.skippable() {
+            None
         } else {
-            if self.skippable() { None } else { Some(Ok(dent)) }
+            Some(Ok(dent))
         }
     }
 
@@ -735,7 +752,8 @@ impl IntoIter {
             if self.depth < self.deferred_dirs.len() {
                 // Unwrap is safe here because we've guaranteed that
                 // `self.deferred_dirs.len()` can never be less than 1
-                let deferred : DirEntry = self.deferred_dirs.pop().expect("This is a bug in walkdir");
+                let deferred: DirEntry = self.deferred_dirs.pop()
+                    .expect("bug in walkdir");
                 if !self.skippable() {
                     return Some(deferred);
                 }
@@ -746,11 +764,15 @@ impl IntoIter {
 
     fn push(&mut self, dent: &DirEntry) {
         // Make room for another open file descriptor if we've hit the max.
-        if self.stack_list.len().checked_sub(self.oldest_opened).unwrap() == self.opts.max_open {
+        let free = self.stack_list
+            .len()
+            .checked_sub(self.oldest_opened).unwrap();
+        if free == self.opts.max_open {
             self.stack_list[self.oldest_opened].close();
-            // Unwrap is safe here because self.oldest_opened is guaranteed to never be
-            // greater than `self.stack_list.len()`, which implies that the subtraction won't
-            // underflow and that adding 1 will never overflow.
+            // Unwrap is safe here because self.oldest_opened is guaranteed to
+            // never be greater than `self.stack_list.len()`, which implies
+            // that the subtraction won't underflow and that adding 1 will
+            // never overflow.
             self.oldest_opened = self.oldest_opened.checked_add(1).unwrap();
         }
         // Open a handle to reading the directory's entries.
@@ -859,9 +881,9 @@ impl DirEntry {
     ///
     /// Note that this *always* returns the path reported by the underlying
     /// directory entry, even when symbolic links are followed. To get the
-    /// target path, use [`path_is_symlink`] to (cheaply) check if
-    /// this entry corresponds to a symbolic link, and [`std::fs::read_link`] to
-    /// resolve the target.
+    /// target path, use [`path_is_symlink`] to (cheaply) check if this entry
+    /// corresponds to a symbolic link, and [`std::fs::read_link`] to resolve
+    /// the target.
     ///
     /// [`WalkDir::new`]: struct.WalkDir.html#method.new
     /// [`path_is_symlink`]: struct.DirEntry.html#method.path_is_symlink
@@ -898,8 +920,9 @@ impl DirEntry {
     ///
     /// # Errors
     ///
-    /// Similar to [`std::fs::metadata`], returns errors for path values that the program does not
-    /// have permissions to access or if the path does not exist.
+    /// Similar to [`std::fs::metadata`], returns errors for path values that
+    /// the program does not have permissions to access or if the path does not
+    /// exist.
     ///
     /// [`WalkDir`]: struct.WalkDir.html
     /// [`follow_links`]: struct.WalkDir.html#method.follow_links
@@ -1030,14 +1053,15 @@ impl fmt::Debug for DirEntry {
     }
 }
 
-/// A recursive directory iterator that skips entries.  Returned by calling [`.filter_entry()`] on
-/// an `IntoIter`, which is formed by calling [`.into_iter()`] on a `WalkDir`.
+/// A recursive directory iterator that skips entries. Returned by calling
+/// [`.filter_entry()`] on an `IntoIter`, which is formed by calling
+/// [`.into_iter()`] on a `WalkDir`.
 ///
 /// Directories that fail the predicate `P` are skipped. Namely, they are
 /// never yielded and never descended into.
 ///
-/// Entries that are skipped with the [`min_depth`] and [`max_depth`] options are
-/// not passed through this filter.
+/// Entries that are skipped with the [`min_depth`] and [`max_depth`] options
+/// are not passed through this filter.
 ///
 /// If opening a handle to a directory resulted in an error, then it is yielded
 /// and no corresponding call to the predicate is made.
@@ -1056,14 +1080,16 @@ pub struct FilterEntry<I, P> {
 }
 
 impl<P> Iterator for FilterEntry<IntoIter, P>
-              where P: FnMut(&DirEntry) -> bool {
+where P: FnMut(&DirEntry) -> bool
+{
     type Item = Result<DirEntry>;
+
     /// Advances the iterator and returns the next value.
     ///
     /// # Errors
     ///
-    /// If the iterator fails to retrieve the next value, this method returns an error value.
-    /// The error will be wrapped in an Option::Some.
+    /// If the iterator fails to retrieve the next value, this method returns
+    /// an error value. The error will be wrapped in an `Option::Some`.
     fn next(&mut self) -> Option<Result<DirEntry>> {
         loop {
             let dent = match self.it.next() {
@@ -1081,8 +1107,7 @@ impl<P> Iterator for FilterEntry<IntoIter, P>
     }
 }
 
-impl<P> FilterEntry<IntoIter, P>
-        where P: FnMut(&DirEntry) -> bool {
+impl<P> FilterEntry<IntoIter, P> where P: FnMut(&DirEntry) -> bool {
     /// Yields only entries which satisfy the given predicate and skips
     /// descending into directories that do not satisfy the given predicate.
     ///
@@ -1120,6 +1145,11 @@ impl<P> FilterEntry<IntoIter, P>
     ///
     /// Note that entries skipped with [`min_depth`] and [`max_depth`] are not
     /// passed to this predicate.
+    ///
+    /// Note that if the iterator has `contents_first` enabled, then this
+    /// method is no different than calling the standard `Iterator::filter`
+    /// method (because directory entries are yielded after they've been
+    /// descended into).
     ///
     /// [`skip_current_dir`]: #method.skip_current_dir
     /// [`min_depth`]: struct.WalkDir.html#method.min_depth
@@ -1178,8 +1208,8 @@ impl<P> FilterEntry<IntoIter, P>
 
 /// An error produced by recursively walking a directory.
 ///
-/// This error type is a light wrapper around [`std::io::Error`]. In particular,
-/// it adds the following information:
+/// This error type is a light wrapper around [`std::io::Error`]. In
+/// particular, it adds the following information:
 ///
 /// * The depth at which the error occurred in the file tree, relative to the
 /// root.
@@ -1242,8 +1272,8 @@ impl Error {
 
     /// Returns the depth at which this error occurred relative to the root.
     ///
-    /// The smallest depth is `0` and always corresponds to the path given
-    /// to the [`new`] function on [`WalkDir`]. Its direct descendents have depth
+    /// The smallest depth is `0` and always corresponds to the path given to
+    /// the [`new`] function on [`WalkDir`]. Its direct descendents have depth
     /// `1`, and their descendents have depth `2`, and so on.
     ///
     /// [`new`]: struct.WalkDir.html#method.new

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -71,7 +71,7 @@ impl Tree {
         for result in f(WalkDir::new(p).contents_first(true)) {
             let dentry = try!(result);
 
-            let tree = 
+            let tree =
             if dentry.file_type().is_dir() {
                 let any_contents = contents_of_dir_at_depth.remove(
                     &(dentry.depth+1));
@@ -90,7 +90,7 @@ impl Tree {
                     dentry.depth).or_insert(vec!()).push(tree);
             min_depth = cmp::min(min_depth, dentry.depth);
         }
-        Ok(Tree::Dir(top_level_path, 
+        Ok(Tree::Dir(top_level_path,
                 contents_of_dir_at_depth.remove(&min_depth)
                 .unwrap_or_default()))
     }
@@ -761,13 +761,16 @@ fn walk_dir_sort() {
     let tmp_path = tmp.path();
     let tmp_len = tmp_path.to_str().unwrap().len();
     exp.create_in(tmp_path).unwrap();
-    let it = WalkDir::new(tmp_path).sort_by(|a,b| a.file_name().cmp(b.file_name())).into_iter();
+    let it = WalkDir::new(tmp_path)
+        .sort_by(|a,b| a.file_name().cmp(b.file_name()))
+        .into_iter();
     let got = it.map(|d| {
         let path = d.unwrap();
         let path = &path.path().to_str().unwrap()[tmp_len..];
         path.replace("\\", "/")
     }).collect::<Vec<String>>();
-    assert_eq!(got,
+    assert_eq!(
+        got,
         ["", "/foo", "/foo/abc", "/foo/abc/fit", "/foo/bar", "/foo/faz"]);
 }
 
@@ -782,14 +785,17 @@ fn walk_dir_sort_small_fd_max() {
     let tmp_path = tmp.path();
     let tmp_len = tmp_path.to_str().unwrap().len();
     exp.create_in(tmp_path).unwrap();
-    let it =
-        WalkDir::new(tmp_path).max_open(1).sort_by(|a,b| a.file_name().cmp(b.file_name())).into_iter();
+    let it = WalkDir::new(tmp_path)
+        .max_open(1)
+        .sort_by(|a,b| a.file_name().cmp(b.file_name()))
+        .into_iter();
     let got = it.map(|d| {
         let path = d.unwrap();
         let path = &path.path().to_str().unwrap()[tmp_len..];
         path.replace("\\", "/")
     }).collect::<Vec<String>>();
-    assert_eq!(got,
+    assert_eq!(
+        got,
         ["", "/foo", "/foo/abc", "/foo/abc/fit", "/foo/bar", "/foo/faz"]);
 }
 

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -2,7 +2,8 @@ use DirEntry;
 
 /// Unix-specific extension methods for `walkdir::DirEntry`
 pub trait DirEntryExt {
-    /// Returns the underlying `d_ino` field in the contained `dirent` structure.
+    /// Returns the underlying `d_ino` field in the contained `dirent`
+    /// structure.
     fn ino(&self) -> u64;
 }
 


### PR DESCRIPTION
This PR contains a smattering of commits that should bring walkdir up to 2.0. Most commits are just polishing, but also:

1. The `DirEntryExt` trait wasn't actually exported. That's done now.
2. I optimized the symbolic link checking loop in an attempt to fix this [ripgrep bug](https://github.com/BurntSushi/ripgrep/issues/633). It's not related to 2.0, but I was in the code and it was an easy enough change.
3. Upgrade to use `same-file 1.0`, which was just released.