### PR TITLE
deps: bump quickcheck to 0.6 and rand to 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ same-file = "1"
 
 [dev-dependencies]
 docopt = "0.8"
-quickcheck = { version = "0.4", default-features = false }
-rand = "0.3"
+quickcheck = { version = "0.6", default-features = false }
+rand = "0.4"
 serde = "1"
 serde_derive = "1"


### PR DESCRIPTION
This is a rollup of #86 and #87.

cc @ignatenkobrain (The quickcheck and rand deps are linked since rand is a public dependency of quickcheck.)