### PR TITLE
Option to stay on same file system

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,10 @@ appveyor = { repository = "BurntSushi/walkdir" }
 [dependencies]
 same-file = "1"
 
+[target.'cfg(windows)'.dependencies]
+kernel32-sys = "0.2.2"
+winapi = { version = "0.3.2", features = ["winuser", "fileapi", "winbase", "winnt"] }
+
 [dev-dependencies]
 docopt = "0.8"
 quickcheck = { version = "0.6", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,8 +20,7 @@ appveyor = { repository = "BurntSushi/walkdir" }
 same-file = "1"
 
 [target.'cfg(windows)'.dependencies]
-kernel32-sys = "0.2.2"
-winapi = { version = "0.3.2", features = ["winuser", "fileapi", "winbase", "winnt"] }
+winapi = { version = "0.3.2", features = ["fileapi", "winbase", "winnt"] }
 
 [dev-dependencies]
 docopt = "0.8"

--- a/examples/walkdir.rs
+++ b/examples/walkdir.rs
@@ -15,14 +15,15 @@ Usage:
 
 Options:
     -h, --help
-    -L, --follow-links   Follow symlinks.
-    --min-depth NUM      Minimum depth.
-    --max-depth NUM      Maximum depth.
-    -n, --fd-max NUM     Maximum open file descriptors. [default: 32]
-    --tree               Show output as a tree.
-    --sort               Sort the output.
-    -q, --ignore-errors  Ignore errors.
-    -d, --depth          Show directory's contents before the directory itself.
+    -L, --follow-links      Follow symlinks.
+    --min-depth NUM         Minimum depth.
+    --max-depth NUM         Maximum depth.
+    -n, --fd-max NUM        Maximum open file descriptors. [default: 32]
+    --tree                  Show output as a tree.
+    --sort                  Sort the output.
+    -q, --ignore-errors     Ignore errors.
+    -d, --depth             Show directory's contents before the directory itself.
+    --same-file-system      Stay on the same file system.
 ";
 
 #[derive(Debug, Deserialize)]
@@ -37,6 +38,7 @@ struct Args {
     flag_ignore_errors: bool,
     flag_sort: bool,
     flag_depth: bool,
+    flag_same_file_system: bool,
 }
 
 macro_rules! wout { ($($tt:tt)*) => { {writeln!($($tt)*)}.unwrap() } }
@@ -52,7 +54,8 @@ fn main() {
         .max_open(args.flag_fd_max)
         .follow_links(args.flag_follow_links)
         .min_depth(mind)
-        .max_depth(maxd);
+        .max_depth(maxd)
+        .same_file_system(args.flag_same_file_system);
     if args.flag_sort {
         walkdir = walkdir.sort_by(|a,b| a.file_name().cmp(b.file_name()));
     }

--- a/examples/walkdir.rs
+++ b/examples/walkdir.rs
@@ -23,7 +23,7 @@ Options:
     --sort                  Sort the output.
     -q, --ignore-errors     Ignore errors.
     -d, --depth             Show directory's contents before the directory itself.
-    --same-file-system      Stay on the same file system.
+    -x --same-file-system   Stay on the same file system.
 ";
 
 #[derive(Debug, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,7 +254,7 @@ struct WalkDirOptions {
     #[cfg(unix)]
     root_device: Option<Result<u64>>,
     #[cfg(windows)]
-    root_device: Option<Result<i32>>,
+    root_device: Option<Result<u32>>,
     root_path: PathBuf,
 }
 
@@ -489,8 +489,8 @@ fn get_device_num<P: AsRef<Path>>(path: P)-> std::io::Result<u64> {
 }
 
 #[cfg(windows)]
-fn get_device_num<P: AsRef<Path>>(path: P) -> std::io::Result<i32> {
-    windows::windows_file_handle_info(path)
+fn get_device_num<P: AsRef<Path>>(path: P) -> std::io::Result<u32> {
+    windows::windows_file_handle_info(path).map(|info| info.dwVolumeSerialNumber)
 }
 
 impl IntoIterator for WalkDir {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -246,6 +246,7 @@ struct WalkDirOptions {
         FnMut(&DirEntry,&DirEntry) -> Ordering + Send + Sync + 'static
     >>,
     contents_first: bool,
+    same_file_system: bool,
 }
 
 impl fmt::Debug for WalkDirOptions {
@@ -263,6 +264,7 @@ impl fmt::Debug for WalkDirOptions {
             .field("max_depth", &self.max_depth)
             .field("sorter", &sorter_str)
             .field("contents_first", &self.contents_first)
+            .field("same_file_system", &self.same_file_system)
             .finish()
     }
 }
@@ -282,6 +284,7 @@ impl WalkDir {
                 max_depth: ::std::usize::MAX,
                 sorter: None,
                 contents_first: false,
+                same_file_system: false,
             },
             root: root.as_ref().to_path_buf(),
         }
@@ -445,6 +448,12 @@ impl WalkDir {
     /// ```
     pub fn contents_first(mut self, yes: bool) -> Self {
         self.opts.contents_first = yes;
+        self
+    }
+
+    /// Do not cross filesystem boundaries.
+    pub fn same_file_system(mut self, yes: bool) -> Self {
+        self.opts.same_file_system = yes;
         self
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -484,7 +484,7 @@ impl WalkDir {
     #[cfg(windows)]
     fn get_root_device(&self) -> Result<u64> {
         windows::windows_file_handle_info(&self.root)
-            .map(|d|d.dwVolumeSerialNumber as u64)
+            .map(|d| d.dwVolumeSerialNumber as u64)
             .map_err(|e| Error::from_path(0, self.root.clone(), e))
     }
 }
@@ -849,7 +849,7 @@ impl IntoIter {
     #[cfg(windows)]
     fn is_same_file_system(&self, dent: &DirEntry) -> Result<bool> {
         let by_handle_file_info = windows::windows_file_handle_info(&dent.path)
-            .map_err(|err| { Error::from_entry(dent, err) })?;
+            .map_err(|err| Error::from_entry(dent, err))?;
         // We cannot take the error from self since it's borrowed, so we make a new error.
         // If the root_device is unknown, every entry will fail.
         match self.opts.root_device {
@@ -868,8 +868,7 @@ impl IntoIter {
             dent = itry!(self.follow(dent));
         }
         if self.opts.same_file_system && dent.depth != 0 {
-            let same_file_system = itry!(self.is_same_file_system(&dent));
-            if !same_file_system {
+            if !itry!(self.is_same_file_system(&dent)) {
                 return None
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1095,7 +1095,6 @@ impl DirEntry {
         }.map_err(|err| Error::from_entry(self, err))
     }
 
-
     /// Return the file type for the file that this entry points to.
     ///
     /// If this is a symbolic link and [`follow_links`] is `true`, then this
@@ -1125,7 +1124,6 @@ impl DirEntry {
         self.depth
     }
 
-    #[cfg(windows)]
     /// Returns true if and only if this entry points to a directory.
     ///
     /// This works around a bug in Rust's standard library:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,10 @@ extern crate quickcheck;
 #[cfg(test)]
 extern crate rand;
 extern crate same_file;
+#[cfg(windows)]
+extern crate winapi;
+#[cfg(windows)]
+extern crate kernel32;
 
 use std::cmp::{Ordering, min};
 use std::error;
@@ -126,11 +130,13 @@ use same_file::Handle;
 #[cfg(unix)]
 pub use unix::DirEntryExt;
 #[cfg(windows)]
-use winapi::fileapi::BY_HANDLE_FILE_INFORMATION;
+use winapi::um::fileapi::BY_HANDLE_FILE_INFORMATION;
 #[cfg(test)]
 mod tests;
 #[cfg(unix)]
 mod unix;
+#[cfg(windows)]
+mod windows;
 
 /// Like try, but for iterators that return [`Option<Result<_, _>>`].
 ///
@@ -1133,12 +1139,11 @@ impl DirEntry {
         })
     }
 
-
     #[cfg(windows)]
     fn from_link(depth: usize, pb: PathBuf) -> Result<DirEntry> {
         let md = fs::metadata(&pb).map_err(|err| {
             Error::from_path(depth, pb.clone(), err)
-        });
+        })?;
         let by_handle_file_info = windows::windows_file_handle_info(&pb).map_err(|err| {
             Error::from_path(depth, pb.clone(), err)
         })?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -462,7 +462,7 @@ impl WalkDir {
     pub fn same_file_system(mut self, yes: bool) -> Self {
         self.opts.same_file_system = yes;
         if self.opts.same_file_system == true {
-            self.opts.root_device = self.get_root_device();
+            self.opts.root_device = Some(self.get_root_device());
         } else {
             self.opts.root_device = None;
         }
@@ -471,19 +471,19 @@ impl WalkDir {
     }
 
     #[cfg(unix)]
-    fn get_root_device(&self) -> Option<Result<u64>> {
+    fn get_root_device(&self) -> Result<u64> {
         use std::os::unix::fs::MetadataExt;
-        Some(self.root.metadata()
+        self.root.metadata()
             .map(|md| md.dev())
             .map_err(|e| Error::from_path(0, self.root.clone(),e))
-        )
+
     }
 
     #[cfg(windows)]
-    fn get_root_device(&self) -> Option<Result<u64>> {
-        Some(windows::windows_file_handle_info(&self.root)
+    fn get_root_device(&self) -> Result<u64> {
+        windows::windows_file_handle_info(&self.root)
             .map(|d|d.dwVolumeSerialNumber as u64)
-            .map_err(|e| Error::from_path(0, self.root.clone(), e)))
+            .map_err(|e| Error::from_path(0, self.root.clone(), e))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,11 +290,6 @@ impl WalkDir {
                 contents_first: false,
                 same_file_system: false,
                 root_device: None,
-//                root_device: Err(Error::from_io(0,
-//                                                std::io::Error::new(
-//                                                    std::io::ErrorKind::Other,
-//                                                    "root device not detected sought yet"))
-//                ),
             },
             root: root.as_ref().to_path_buf(),
         }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -542,6 +542,30 @@ fn walk_dir_sym_follow_dir() {
     assert_tree_eq!(followed, got);
 }
 
+// We cannot mount different volumes for the sake of the test, but
+// on Linux systems we can assume that /sys is a mounted volume.
+#[test]
+#[cfg(target_os = "linux")]
+fn walk_dir_stay_on_file_system() {
+    let actual = td("same_file", vec![
+        td("a", vec![tld("/sys", "alink")]),
+    ]);
+    let unfollowed = td("same_file", vec![
+        td("a", vec![tld("/sys", "alink")]),
+    ]);
+    let (_tmp, got) = dir_setup_with(&actual, |wd| wd);
+    assert_tree_eq!(unfollowed, got);
+
+    let actual = td("same_file", vec![
+        td("a", vec![tld("/sys", "alink")]),
+    ]);
+    let followed = td("same_file", vec![
+        td("a", vec![]),
+    ]);
+    let (_tmp, got) = dir_setup_with(&actual, |wd| wd.follow_links(true).same_file_system(true));
+    assert_tree_eq!(followed, got);
+}
+
 #[test]
 #[cfg(unix)]
 fn walk_dir_sym_detect_loop() {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,15 +1,12 @@
-#[cfg(windows)]
-extern crate kernel32;
-#[cfg(windows)]
 extern crate winapi;
 use std::io::Error;
 use std::path::PathBuf;
 use std::mem;
-use winapi::um::fileapi::BY_HANDLE_FILE_INFORMATION;
-use winapi::um::winnt::HANDLE;
-use winapi::um::winbase::FILE_FLAG_BACKUP_SEMANTICS;
+use self::winapi::um::winnt::HANDLE;
+use self::winapi::um::winbase::FILE_FLAG_BACKUP_SEMANTICS;
+pub use self::winapi::um::fileapi::BY_HANDLE_FILE_INFORMATION;
 
-#[cfg(windows)]
+/// uses winapi to get Windows file metadata
 pub fn windows_file_handle_info(pbuf: &PathBuf) -> Result<BY_HANDLE_FILE_INFORMATION, Error> {
 
     extern "system" {
@@ -21,14 +18,13 @@ pub fn windows_file_handle_info(pbuf: &PathBuf) -> Result<BY_HANDLE_FILE_INFORMA
 
     // The FILE_FLAG_BACKUP_SEMANTICS flag is needed to open directories
     // https://msdn.microsoft.com/en-us/library/windows/desktop/aa365258(v=vs.85).aspx
-    let file = OpenOptions::new()
+    let opened_file = OpenOptions::new()
         .create(false)
         .write(false)
         .read(true)
         .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
-        .open(pbuf.as_path());
+        .open(pbuf.as_path())?;
 
-    let opened_file = file.unwrap();
     unsafe {
         let mut ainfo = mem::zeroed();
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -20,14 +20,13 @@ pub fn windows_file_handle_info(pbuf: &PathBuf) -> Result<BY_HANDLE_FILE_INFORMA
         .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
         .open(pbuf.as_path())?;
 
-    unsafe {
-        let mut ainfo = mem::zeroed();
-
-        let return_code = GetFileInformationByHandle(opened_file.as_raw_handle(), &mut ainfo);
-        // 0 is an error
-        match return_code {
-            0_i32 => Err(Error::last_os_error()),
-            _ => Ok(ainfo),
-        }
+    let mut ainfo = mem::zeroed();
+    let code = unsafe {
+        GetFileInformationByHandle(opened_file.as_raw_handle(), &mut ainfo)
+    };
+    if code == 0 {
+        Err(Error::last_os_error())
+    } else {
+        Ok(ainfo)
     }
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,0 +1,42 @@
+#[cfg(windows)]
+extern crate kernel32;
+#[cfg(windows)]
+extern crate winapi;
+use std::io::Error;
+use std::path::PathBuf;
+use std::mem;
+use winapi::fileapi::BY_HANDLE_FILE_INFORMATION;
+use winapi::winnt::HANDLE;
+use winapi::winbase::FILE_FLAG_BACKUP_SEMANTICS;
+
+#[cfg(windows)]
+pub fn windows_file_handle_info(pbuf: &PathBuf) -> Result<BY_HANDLE_FILE_INFORMATION, Error> {
+
+    extern "system" {
+        fn GetFileInformationByHandle(a: HANDLE, b: *mut BY_HANDLE_FILE_INFORMATION) -> i32;
+    }
+
+    use std::fs::OpenOptions;
+    use std::os::windows::prelude::*;
+
+    // The FILE_FLAG_BACKUP_SEMANTICS flag is needed to open directories
+    // https://msdn.microsoft.com/en-us/library/windows/desktop/aa365258(v=vs.85).aspx
+    let file = OpenOptions::new()
+        .create(false)
+        .write(false)
+        .read(true)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
+        .open(pbuf.as_path());
+
+    let opened_file = file.unwrap();
+    unsafe {
+        let mut ainfo = mem::zeroed();
+
+        let return_code = GetFileInformationByHandle(opened_file.as_raw_handle(), &mut ainfo);
+        // 0 is an error
+        match return_code {
+            0_i32 => Err(Error::last_os_error()),
+            _ => Ok(ainfo),
+        }
+    }
+}

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -2,9 +2,9 @@ use std::io::Error;
 use std::mem;
 use std::path::PathBuf;
 
-use self::winapi::um::fileapi::{GetFileInformationByHandle, BY_HANDLE_FILE_INFORMATION};
-use self::winapi::um::winbase::FILE_FLAG_BACKUP_SEMANTICS;
-use self::winapi::um::winnt::HANDLE;
+use winapi::um::fileapi::{GetFileInformationByHandle, BY_HANDLE_FILE_INFORMATION};
+use winapi::um::winbase::FILE_FLAG_BACKUP_SEMANTICS;
+use winapi::um::winnt::HANDLE;
 
 /// uses winapi to get Windows file metadata
 pub fn windows_file_handle_info(pbuf: &PathBuf) -> Result<BY_HANDLE_FILE_INFORMATION, Error> {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,19 +1,13 @@
-extern crate winapi;
 use std::io::Error;
-use std::path::PathBuf;
 use std::mem;
-use self::winapi::um::winnt::HANDLE;
+use std::path::PathBuf;
+
+use self::winapi::um::fileapi::{GetFileInformationByHandle, BY_HANDLE_FILE_INFORMATION};
 use self::winapi::um::winbase::FILE_FLAG_BACKUP_SEMANTICS;
-use self::winapi::um::fileapi::BY_HANDLE_FILE_INFORMATION;
+use self::winapi::um::winnt::HANDLE;
 
 /// uses winapi to get Windows file metadata
 pub fn windows_file_handle_info(pbuf: &PathBuf) -> Result<BY_HANDLE_FILE_INFORMATION, Error> {
-
-    extern "system" {
-        // https://msdn.microsoft.com/en-us/library/windows/desktop/aa363788(v=vs.85).aspx
-        fn GetFileInformationByHandle(a: HANDLE, b: *mut BY_HANDLE_FILE_INFORMATION) -> i32;
-    }
-
     use std::fs::OpenOptions;
     use std::os::windows::prelude::*;
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -4,7 +4,6 @@ use std::path::PathBuf;
 
 use winapi::um::fileapi::{GetFileInformationByHandle, BY_HANDLE_FILE_INFORMATION};
 use winapi::um::winbase::FILE_FLAG_BACKUP_SEMANTICS;
-use winapi::um::winnt::HANDLE;
 
 /// uses winapi to get Windows file metadata
 pub fn windows_file_handle_info(pbuf: &PathBuf) -> Result<BY_HANDLE_FILE_INFORMATION, Error> {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -5,9 +5,9 @@ extern crate winapi;
 use std::io::Error;
 use std::path::PathBuf;
 use std::mem;
-use winapi::fileapi::BY_HANDLE_FILE_INFORMATION;
-use winapi::winnt::HANDLE;
-use winapi::winbase::FILE_FLAG_BACKUP_SEMANTICS;
+use winapi::um::fileapi::BY_HANDLE_FILE_INFORMATION;
+use winapi::um::winnt::HANDLE;
+use winapi::um::winbase::FILE_FLAG_BACKUP_SEMANTICS;
 
 #[cfg(windows)]
 pub fn windows_file_handle_info(pbuf: &PathBuf) -> Result<BY_HANDLE_FILE_INFORMATION, Error> {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -4,12 +4,13 @@ use std::path::PathBuf;
 use std::mem;
 use self::winapi::um::winnt::HANDLE;
 use self::winapi::um::winbase::FILE_FLAG_BACKUP_SEMANTICS;
-pub use self::winapi::um::fileapi::BY_HANDLE_FILE_INFORMATION;
+use self::winapi::um::fileapi::BY_HANDLE_FILE_INFORMATION;
 
 /// uses winapi to get Windows file metadata
 pub fn windows_file_handle_info(pbuf: &PathBuf) -> Result<BY_HANDLE_FILE_INFORMATION, Error> {
 
     extern "system" {
+        // https://msdn.microsoft.com/en-us/library/windows/desktop/aa363788(v=vs.85).aspx
         fn GetFileInformationByHandle(a: HANDLE, b: *mut BY_HANDLE_FILE_INFORMATION) -> i32;
     }
 


### PR DESCRIPTION
https://github.com/BurntSushi/walkdir/issues/8

There's a good bit going on here. 

- added `--same-file-system`/`-x` opt
- added `is_same_file_system` function to DirEntry iterator.
- added a `windows` module that uses `winapi`  to call for `BY_HANDLE_FILE_INFORMATION`. All that is technically need from there is `dwVolumeSerialNumber`, but I thought it would be a waste to go through the trouble of getting that metadata without giving users the option to use it themselves. Maybe that's a leaky abstraction, but it's essentially what we do with the unix metadata. Also, there are a few places where unwrap is called because I'm not sure we would want to recover if someone calls `-x` and we can't find the root device info. 
- when  `--same-file-system` is true the `root_device` is compared to the DirEntry `metadata.dev` (unix) or `BY_HANDLE_FILE_INFORMATION.dwVolumeSerialNumber` (NT). 
- the Windows version calls for `BY_HANDLE_FILE_INFORMATION` every single time. It might make sense to have something like a `get_metadata` flag that `same_file_system` would trigger. 

I was able to manually test this in a Windows VM, but I didn't add tests. That will probably involve a mock. I want to get some feedback before doing that though. 

Going forward it might might sense to do a full abstraction the Unix and Windows metadata. 

@BurntSushi 

```
C:\vagrant\walkdir>cargo build --examples && target\debug\examples\walkdir.exe -L --same-file-system C:\Users\vagrant\Downloads
   Compiling walkdir v2.0.1 (file:///C:/vagrant/walkdir)
    Finished dev [unoptimized + debuginfo] target(s) in 6.50 secs
C:\Users\vagrant\Downloads
C:\Users\vagrant\Downloads\desktop.ini

C:\vagrant\walkdir>cargo build --examples && target\debug\examples\walkdir.exe -L  C:\Users\vagrant\Downloads
    Finished dev [unoptimized + debuginfo] target(s) in 0.23 secs
C:\Users\vagrant\Downloads
C:\Users\vagrant\Downloads\ddrive
C:\Users\vagrant\Downloads\ddrive\ddrivetext.txt
C:\Users\vagrant\Downloads\desktop.ini
```