### PR TITLE
Fixing broken links when reading docs online

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ yielded by the iterator. Finally, the [`Error`] type is a small wrapper around
 [`std::io::Error`] with additional information, such as if a loop was detected
 while following symbolic links (not enabled by default).
 
-[`WalkDir`]: struct.Walkdir.html
+[`WalkDir`]: struct.WalkDir.html
 [`DirEntry`]: struct.DirEntry.html
 [`Error`]: struct.Error.html
 [`std::io::Error`]: https://doc.rust-lang.org/stable/std/io/struct.Error.html
@@ -73,7 +73,7 @@ for entry in WalkDir::new("foo").follow_links(true) {
 # }
 ```
 
-[`follow_links`]: struct.Walkdir.html#method.follow_links
+[`follow_links`]: struct.WalkDir.html#method.follow_links
 
 # Example: skip hidden files and directories on unix
 


### PR DESCRIPTION
When reading the docs on docs.rs, I found a couple of broken links:

- The first link to `WalkDir` on https://docs.rs/walkdir/2.0.1/walkdir/#from-the-top
- The link to `follow_links` on https://docs.rs/walkdir/2.0.1/walkdir/index.html#example-follow-symbolic-links

Interestingly enough, when previewing the built docs locally I didn't see these problems - it could be that it's possible that browsers (I tested on Safari and Firefox on Mac) treat filenames as case-insensitive and URLs as case-sensitive? I'm not sure why the problem happens in the first place, but these changes bring the capitalization of the doc links in line with that of the `WalkDir` struct, so that should help.

Hope this helps!