### PR TITLE
make regular io errors pretty

### DIFF
--- a/examples/walkdir.rs
+++ b/examples/walkdir.rs
@@ -41,7 +41,13 @@ struct Args {
 
 macro_rules! wout { ($($tt:tt)*) => { {writeln!($($tt)*)}.unwrap() } }
 
+fn pretty_ioerr() -> io::Result<()> {
+    let _ = WalkDir::new("does-not-exist").into_iter().next().unwrap()?;
+    Ok(())
+}
+
 fn main() {
+    println!("Pretty error: {}", pretty_ioerr().unwrap_err());
     let args: Args = Docopt::new(USAGE)
         .and_then(|d| d.deserialize())
         .unwrap_or_else(|e| e.exit());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1468,12 +1468,15 @@ impl fmt::Display for Error {
 }
 
 impl From<Error> for io::Error {
-    fn from(err: Error) -> io::Error {
-        match err {
-            Error { inner: ErrorInner::Io { err, .. }, .. } => err,
-            err @ Error { inner: ErrorInner::Loop { .. }, .. } => {
-                io::Error::new(io::ErrorKind::Other, err)
+    fn from(walk_err: Error) -> io::Error {
+        let kind = match walk_err {
+            Error { inner: ErrorInner::Io { ref err, .. }, .. } => {
+                err.kind()
             }
-        }
+            Error { inner: ErrorInner::Loop { .. }, .. } => {
+                io::ErrorKind::Other
+            }
+        };
+        io::Error::new(kind, walk_err)
     }
 }


### PR DESCRIPTION
This aims to make errors prettier even when they are downcast to `io::Error`. It does this by _slightly_ modifying the type -- I doubt the downcast `io::Error` type is dependend on by anyone, but I suppose this could theoretically be considered a breaking change.

I added a quick `println!` example that should be removed before merging. It prints:

```
Pretty error: IO error for operation on does-not-exist: No such file or directory (os error 2)
```