### PR TITLE
Keep context when converting to io::Error

### DIFF
--- a/examples/walkdir.rs
+++ b/examples/walkdir.rs
@@ -41,7 +41,13 @@ struct Args {
 
 macro_rules! wout { ($($tt:tt)*) => { {writeln!($($tt)*)}.unwrap() } }
 
+fn pretty_ioerr() -> io::Result<()> {
+    let _ = WalkDir::new("does-not-exist").into_iter().next().unwrap()?;
+    Ok(())
+}
+
 fn main() {
+    println!("Pretty error: {}", pretty_ioerr().unwrap_err());
     let args: Args = Docopt::new(USAGE)
         .and_then(|d| d.deserialize())
         .unwrap_or_else(|e| e.exit());

--- a/examples/walkdir.rs
+++ b/examples/walkdir.rs
@@ -41,13 +41,7 @@ struct Args {
 
 macro_rules! wout { ($($tt:tt)*) => { {writeln!($($tt)*)}.unwrap() } }
 
-fn pretty_ioerr() -> io::Result<()> {
-    let _ = WalkDir::new("does-not-exist").into_iter().next().unwrap()?;
-    Ok(())
-}
-
 fn main() {
-    println!("Pretty error: {}", pretty_ioerr().unwrap_err());
     let args: Args = Docopt::new(USAGE)
         .and_then(|d| d.deserialize())
         .unwrap_or_else(|e| e.exit());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1407,6 +1407,18 @@ impl Error {
        }
     }
 
+    /// Similar to [`io_error`] except consumes self to convert to the [`io::Error`],
+    /// if there is one.
+    ///
+    /// [`io_error`]: struct.WalkDir.html#method.io_error
+    /// [`io::Error`]: https://doc.rust-lang.org/stable/std/io/struct.Error.html
+    pub fn into_io_error(self) -> Option<io::Error> {
+       match self.inner {
+            ErrorInner::Io { err, .. } => Some(err),
+            ErrorInner::Loop { .. } => None,
+       }
+    }
+
     fn from_path(depth: usize, pb: PathBuf, err: io::Error) -> Self {
         Error {
             depth: depth,
@@ -1468,12 +1480,15 @@ impl fmt::Display for Error {
 }
 
 impl From<Error> for io::Error {
-    fn from(err: Error) -> io::Error {
-        match err {
-            Error { inner: ErrorInner::Io { err, .. }, .. } => err,
-            err @ Error { inner: ErrorInner::Loop { .. }, .. } => {
-                io::Error::new(io::ErrorKind::Other, err)
+    fn from(walk_err: Error) -> io::Error {
+        let kind = match walk_err {
+            Error { inner: ErrorInner::Io { ref err, .. }, .. } => {
+                err.kind()
             }
-        }
+            Error { inner: ErrorInner::Loop { .. }, .. } => {
+                io::ErrorKind::Other
+            }
+        };
+        io::Error::new(kind, walk_err)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1282,12 +1282,13 @@ impl<P> FilterEntry<IntoIter, P> where P: FnMut(&DirEntry) -> bool {
 /// case, there is no underlying IO error.
 ///
 /// To maintain good ergonomics, this type has a
-/// `impl From<Error> for std::io::Error` defined so that you may use an
-/// [`io::Result`] with methods in this crate if you don't care about accessing
-/// the underlying error data in a structured form.
+/// [`impl From<Error> for std::io::Error`][impl] defined which preserves the original context.
+/// This allows you to use an [`io::Result`] with methods in this crate if you don't care about
+/// accessing the underlying error data in a structured form.
 ///
 /// [`std::io::Error`]: https://doc.rust-lang.org/stable/std/io/struct.Error.html
 /// [`io::Result`]: https://doc.rust-lang.org/stable/std/io/type.Result.html
+/// [impl]: struct.Error.html#impl-From%3CError%3E
 #[derive(Debug)]
 pub struct Error {
     depth: usize,
@@ -1346,17 +1347,19 @@ impl Error {
         self.depth
     }
 
-    /// Inspect the underlying [`io::Error`] if there is one.
+    /// Inspect the original [`io::Error`] if there is one.
     ///
     /// [`None`] is returned if the [`Error`] doesn't correspond to an
     /// [`io::Error`]. This might happen, for example, when the error was
     /// produced because a cycle was found in the directory tree while
     /// following symbolic links.
     ///
-    /// This method returns a borrowed value that is bound to the lifetime of
-    /// the [`Error`]. To obtain an owned value, the [`From`] trait can be used
-    /// instead, in which case if the [`Error`] being being converted doesn't
-    /// correspond to an [`io::Error`], a new one will be created.
+    /// This method returns a borrowed value that is bound to the lifetime of the [`Error`]. To
+    /// obtain an owned value, the [`into_io_error`] can be used instead.
+    ///
+    /// > This is the original [`io::Error`] and is _not_ the same as
+    /// > [`impl From<Error> for std::io::Error`][impl] which contains additional context about the
+    /// error.
     ///
     /// # Example
     ///
@@ -1400,6 +1403,8 @@ impl Error {
     /// [`io::Error`]: https://doc.rust-lang.org/stable/std/io/struct.Error.html
     /// [`From`]: https://doc.rust-lang.org/stable/std/convert/trait.From.html
     /// [`Error`]: struct.Error.html
+    /// [`into_io_error`]: struct.Error.html#method.into_io_error
+    /// [impl]: struct.Error.html#impl-From%3CError%3E
     pub fn io_error(&self) -> Option<&io::Error> {
        match self.inner {
             ErrorInner::Io { ref err, .. } => Some(err),
@@ -1407,10 +1412,10 @@ impl Error {
        }
     }
 
-    /// Similar to [`io_error`] except consumes self to convert to the [`io::Error`],
-    /// if there is one.
+    /// Similar to [`io_error`] except consumes self to convert to the original
+    /// [`io::Error`] if one exists.
     ///
-    /// [`io_error`]: struct.WalkDir.html#method.io_error
+    /// [`io_error`]: struct.Error.html#method.io_error
     /// [`io::Error`]: https://doc.rust-lang.org/stable/std/io/struct.Error.html
     pub fn into_io_error(self) -> Option<io::Error> {
        match self.inner {
@@ -1480,6 +1485,15 @@ impl fmt::Display for Error {
 }
 
 impl From<Error> for io::Error {
+    /// Convert the [`Error`] to an [`io::Error`], preserving the original [`Error`] as the ["inner
+    /// error"]. Note that this also makes the display of the error include the context.
+    ///
+    /// This is different from [`into_io_error`] which returns the original [`io::Error`].
+    ///
+    /// [`Error`]: struct.Error.html
+    /// [`io::Error`]: https://doc.rust-lang.org/stable/std/io/struct.Error.html
+    /// ["inner error"]: https://doc.rust-lang.org/std/io/struct.Error.html#method.into_inner
+    /// [`into_io_error`]: struct.WalkDir.html#method.into_io_error
     fn from(walk_err: Error) -> io::Error {
         let kind = match walk_err {
             Error { inner: ErrorInner::Io { ref err, .. }, .. } => {


### PR DESCRIPTION
This change will keep "pretty" error messages even when the error has been converted to `io::Error`.

Example:
```
Pretty error: IO error for operation on /path/does-not-exist: No such file or directory (os error 2)
```

## Justification
The standard library returns `std::io::Error` for failed filesystem operations. `io::Error` is an extremely lightweight type which typically uses `&'static str` for its "caused-by" `error` argument to keep it even _more_ lightweight. Many filesystem operations _could_ include path information, but they don't -- probably for performance and compatibility reasons.

However, the [type itself](https://doc.rust-lang.org/std/io/struct.Error.html) makes no requirements on what the "caused-by" `error` type is. When the type is returned unmodified from `std::fs` or `std::path` methods it doesn't include context (for the above reasons). This makes working with files extremely difficult especially while debugging or trying to present a simple error to a user. In order to include context information it is necessary to do something like:

```
file.set_permissions(perm)
    .map_err(|err| io::Error::new(err.kind(), format!("{} while setting permisions for {}", err, path.display())))?;
```

As you can imagine this can lead to a lot of code duplication.

Walkdir solves this problem, as detailed in **Solution** below. Other libraries also solve the same problem. However, if using them both from within the same function (and not wanting to use `Failure` or similar type) you are forced to use `io::Error` as the intermediate error type (for ergonomic reasons).

For instance, [this example](https://docs.rs/ergo_fs/0.1.0/ergo_fs/#examples) which is a non-contrived example that will happen quite often in the new `ergo_fs` library:
```
use ergo_fs::{WalkDir, PathType};

fn some_fn(...) -> io::Result<_> {
    for entry in WalkDir::new("foo").min_depth(1) {
        match PathType::new(entry?.path())? {
            PathType::File(file) => println!("got file {}", file.display()),
            PathType::Dir(dir) => println!("got dir {}", dir.display()),
        }
    }
}
````

It would not be possible to use _either_ `path_abs::Error` or `walkdir::Error` in that context, and in most cases `io::Error` is all the user wants or needs. However, using `io::Error` in this case will remove the context of the error for all walkdir operations.

## Solution
Walkdir _already_ includes contextual information in its `walkdir::Error` type. However, when converting `From<Error> -> io::Error` walkdir returns the original unaltered io error (if it exists). This strips the contextual information that it had access to.

If instead it returned `io::Error::new(kind, walkdir_err)` there would be zero performance penalties (except when formatting the `io::Error`) but the error messages would be ergonomic regardless of whether it was converted or not.

This solution also adds the `to_io_error` method, which will return the plain unaltered `io::Error` if the user needs it.

## Disadvantages
The major downsides are:
- The error message as well as the `get_ref` result will change. Primarily `get_ref` will actually return _something_ after converting to `io::Error`. This _could_ be considered a semver breaking change, although that would be a _very hard_ reading of an API regression (it is unlikely anyone depends on the current behavior).
- Extremely minor additional memory usage by the `io::Error` after conversion.

I cannot think of additional disdvantages. This has zero cpu cost, does not contribute significantly to the size of the `io::Error` and will be a uniform benefit to the end user of this library.

Thanks for considering this change, and I'm sorry about the rought start in the previous PR

## Edit: additional disadvantage

So there does seem to be one additional downside: [raw_os_error](https://doc.rust-lang.org/std/io/struct.Error.html#method.raw_os_error) appears to be able to return the last raw os error. I _think_ it is doing so by digging into the inner error.

With this change the user would have to use [downcast](https://doc.rust-lang.org/std/error/trait.Error.html#method.downcast) to retrieve the original `walkdir::Error`, which they would then call `into_io_error` on to get the original `io::Error`, from which they could (finally) retrieve the os error number if it existed.

I _seriously_ doubt this is a common need, and for the cases where it is they would _definitely_ be using `walkdir::Error` directly. However, the fact that the specific OS error is less retrievable is a minor disadvantage and minor breaking change.