### PR TITLE
improve stdout in contents_first doc example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -423,10 +423,10 @@ impl WalkDir {
     /// }
     ///
     /// // foo
-    /// // abc
-    /// // qrs
-    /// // tuv
-    /// // def
+    /// // foo/abc
+    /// // foo/abc/qrs
+    /// // foo/abc/tuv
+    /// // foo/def
     /// ```
     ///
     /// With contents_first enabled:
@@ -439,10 +439,10 @@ impl WalkDir {
     ///     println!("{}", entry.path().display());
     /// }
     ///
-    /// // qrs
-    /// // tuv
-    /// // abc
-    /// // def
+    /// // foo/abc/qrs
+    /// // foo/abc/tuv
+    /// // foo/abc
+    /// // foo/def
     /// // foo
     /// ```
     pub fn contents_first(mut self, yes: bool) -> Self {


### PR DESCRIPTION
A big potential question on the reader's mind when reviewing these docs is "what will the paths returned by the iterator be relative to?"  This is the one example on the page which shows output that could potentially answer that question, and to only see filenames is needlessly discouraging.