### PR TITLE
feat(dir_entry): Put is_dir() as a public function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -719,7 +719,7 @@ impl IntoIter {
     ///         Some(Ok(entry)) => entry,
     ///     };
     ///     if is_hidden(&entry) {
-    ///         if entry.file_type().is_dir() {
+    ///         if entry.is_dir() {
     ///             it.skip_current_dir();
     ///         }
     ///         continue;
@@ -1060,7 +1060,7 @@ impl DirEntry {
     /// This works around a bug in Rust's standard library:
     /// https://github.com/rust-lang/rust/issues/46484
     #[cfg(windows)]
-    fn is_dir(&self) -> bool {
+    pub fn is_dir(&self) -> bool {
         use std::os::windows::fs::MetadataExt;
         use winapi::um::winnt::FILE_ATTRIBUTE_DIRECTORY;
         self.metadata.file_attributes() & FILE_ATTRIBUTE_DIRECTORY != 0
@@ -1068,7 +1068,7 @@ impl DirEntry {
 
     /// Returns true if and only if this entry points to a directory.
     #[cfg(not(windows))]
-    fn is_dir(&self) -> bool {
+    pub fn is_dir(&self) -> bool {
         self.ty.is_dir()
     }
 
@@ -1343,7 +1343,7 @@ impl<P> FilterEntry<IntoIter, P> where P: FnMut(&DirEntry) -> bool {
     ///         Some(Ok(entry)) => entry,
     ///     };
     ///     if is_hidden(&entry) {
-    ///         if entry.file_type().is_dir() {
+    ///         if entry.is_dir() {
     ///             it.skip_current_dir();
     ///         }
     ///         continue;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -72,7 +72,7 @@ impl Tree {
             let dentry = try!(result);
 
             let tree =
-            if dentry.file_type().is_dir() {
+            if dentry.is_dir() {
                 let any_contents = contents_of_dir_at_depth.remove(
                     &(dentry.depth+1));
             Tree::Dir(pb(dentry.file_name()), any_contents.unwrap_or_default())
@@ -80,7 +80,7 @@ impl Tree {
                 if dentry.file_type().is_symlink() {
                     let src = try!(dentry.path().read_link());
                     let dst = pb(dentry.file_name());
-                    let dir = dentry.path().is_dir();
+                    let dir = dentry.is_dir();
                     Tree::Symlink { src: src, dst: dst, dir: dir }
                 } else {
                     Tree::File(pb(dentry.file_name()))
@@ -302,7 +302,7 @@ impl Iterator for WalkEventIter {
             None => None,
             Some(Err(err)) => Some(Err(From::from(err))),
             Some(Ok(dent)) => {
-                if dent.file_type().is_dir() {
+                if dent.is_dir() {
                     self.depth += 1;
                     Some(Ok(WalkEvent::Dir(dent)))
                 } else {
@@ -712,7 +712,7 @@ fn walk_dir_filter() {
                      .into_iter()
                      .filter_entry(move |d| {
                          let n = d.file_name().to_string_lossy().into_owned();
-                         !d.file_type().is_dir()
+                         !d.is_dir()
                          || n.starts_with("f")
                          || d.path() == &*tmp_path
                      });


### PR DESCRIPTION
The purpose of this PR is to expose the `DirEntry.is_dir()` publicly. 
As it fixes a bug in the stdlib it should be public so lib users do not need to reimplement it.