### PR TITLE
Fix syntax highlighting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Dual-licensed under MIT or the [UNLICENSE](http://unlicense.org).
 To use this crate, add `walkdir` as a dependency to your project's
 `Cargo.toml`:
 
-```
+```toml
 [dependencies]
 walkdir = "2"
 ```
@@ -111,7 +111,7 @@ allocations as possible.
 I haven't recorded any benchmarks, but here are some things you can try with a
 local checkout of `walkdir`:
 
-```
+```sh
 # The directory you want to recursively walk:
 DIR=$HOME
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ efficiently skip descending into directories.
 To use this crate, add `walkdir` as a dependency to your project's
 `Cargo.toml`:
 
-```text
+```toml
 [dependencies]
 walkdir = "2"
 ```


### PR DESCRIPTION
Before: 
![before SS](https://user-images.githubusercontent.com/6709544/40570522-027297d6-608c-11e8-8e8b-dfd51e4acaa0.png)

After: 
![after SS](https://user-images.githubusercontent.com/6709544/40570527-06e7c9bc-608c-11e8-9466-92f9240f02cb.png)

