### PR TITLE
Fix issue with direntry clone on non-unix and non-windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1108,8 +1108,6 @@ impl DirEntry {
 
     #[cfg(not(any(unix, windows)))]
     fn from_entry(depth: usize, ent: &fs::DirEntry) -> Result<DirEntry> {
-        use std::os::unix::fs::DirEntryExt;
-
         let ty = ent.file_type().map_err(|err| {
             Error::from_path(depth, ent.path(), err)
         })?;
@@ -1153,8 +1151,6 @@ impl DirEntry {
 
     #[cfg(not(any(unix, windows)))]
     fn from_link(depth: usize, pb: PathBuf) -> Result<DirEntry> {
-        use std::os::unix::fs::MetadataExt;
-
         let md = fs::metadata(&pb).map_err(|err| {
             Error::from_path(depth, pb.clone(), err)
         })?;
@@ -1197,7 +1193,6 @@ impl Clone for DirEntry {
             ty: self.ty,
             follow_link: self.follow_link,
             depth: self.depth,
-            ino: self.ino,
         }
     }
 }


### PR DESCRIPTION
This fixes compilation on Redox