### PR TITLE
walkdir: add option to stay on same file system

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ same-file = "1"
 
 [target.'cfg(windows)'.dependencies.winapi]
 version = "0.3"
-features = ["std", "winnt"]
+features = ["std", "fileapi", "winbase", "winnt"]
 
 [dev-dependencies]
 docopt = "1"

--- a/examples/walkdir.rs
+++ b/examples/walkdir.rs
@@ -11,24 +11,25 @@ use walkdir::WalkDir;
 
 const USAGE: &'static str = "
 Usage:
-    walkdir [options] [<dir>]
+    walkdir [options] [<dir> ...]
 
 Options:
     -h, --help
-    -L, --follow-links   Follow symlinks.
-    --min-depth NUM      Minimum depth.
-    --max-depth NUM      Maximum depth.
-    -n, --fd-max NUM     Maximum open file descriptors. [default: 32]
-    --tree               Show output as a tree.
-    --sort               Sort the output.
-    -q, --ignore-errors  Ignore errors.
-    -d, --depth          Show directory's contents before the directory itself.
+    -L, --follow-links       Follow symlinks.
+    --min-depth NUM          Minimum depth.
+    --max-depth NUM          Maximum depth.
+    -n, --fd-max NUM         Maximum open file descriptors. [default: 32]
+    --tree                   Show output as a tree.
+    --sort                   Sort the output.
+    -q, --ignore-errors      Ignore errors.
+    -d, --depth              Show directory's contents before the directory itself.
+    -x, --same-file-system   Stay on the same file system.
 ";
 
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
 struct Args {
-    arg_dir: Option<String>,
+    arg_dir: Option<Vec<String>>,
     flag_follow_links: bool,
     flag_min_depth: Option<usize>,
     flag_max_depth: Option<usize>,
@@ -37,6 +38,7 @@ struct Args {
     flag_ignore_errors: bool,
     flag_sort: bool,
     flag_depth: bool,
+    flag_same_file_system: bool,
 }
 
 macro_rules! wout { ($($tt:tt)*) => { {writeln!($($tt)*)}.unwrap() } }
@@ -47,47 +49,49 @@ fn main() {
         .unwrap_or_else(|e| e.exit());
     let mind = args.flag_min_depth.unwrap_or(0);
     let maxd = args.flag_max_depth.unwrap_or(::std::usize::MAX);
-    let dir = args.arg_dir.clone().unwrap_or(".".to_owned());
-    let mut walkdir = WalkDir::new(dir)
-        .max_open(args.flag_fd_max)
-        .follow_links(args.flag_follow_links)
-        .min_depth(mind)
-        .max_depth(maxd);
-    if args.flag_sort {
-        walkdir = walkdir.sort_by(|a,b| a.file_name().cmp(b.file_name()));
-    }
-    if args.flag_depth {
-        walkdir = walkdir.contents_first(true)
-    }
-    let it = walkdir.into_iter();
-    let mut out = io::BufWriter::new(io::stdout());
-    let mut eout = io::stderr();
-    if args.flag_tree {
-        for dent in it {
-            match dent {
-                Err(err) => {
-                    out.flush().unwrap();
-                    wout!(eout, "ERROR: {}", err);
-                }
-                Ok(dent) => {
-                    let name = dent.file_name().to_string_lossy();
-                    wout!(out, "{}{}", indent(dent.depth()), name);
+    for dir in args.arg_dir.unwrap_or(vec![".".to_string()]) {
+        let mut walkdir = WalkDir::new(dir)
+            .max_open(args.flag_fd_max)
+            .follow_links(args.flag_follow_links)
+            .min_depth(mind)
+            .max_depth(maxd)
+            .same_file_system(args.flag_same_file_system);
+        if args.flag_sort {
+            walkdir = walkdir.sort_by(|a,b| a.file_name().cmp(b.file_name()));
+        }
+        if args.flag_depth {
+            walkdir = walkdir.contents_first(true)
+        }
+        let it = walkdir.into_iter();
+        let mut out = io::BufWriter::new(io::stdout());
+        let mut eout = io::stderr();
+        if args.flag_tree {
+            for dent in it {
+                match dent {
+                    Err(err) => {
+                        out.flush().unwrap();
+                        wout!(eout, "ERROR: {}", err);
+                    }
+                    Ok(dent) => {
+                        let name = dent.file_name().to_string_lossy();
+                        wout!(out, "{}{}", indent(dent.depth()), name);
+                    }
                 }
             }
-        }
-    } else if args.flag_ignore_errors {
-        for dent in it.filter_map(|e| e.ok()) {
-            wout!(out, "{}", dent.path().display());
-        }
-    } else {
-        for dent in it {
-            match dent {
-                Err(err) => {
-                    out.flush().unwrap();
-                    wout!(eout, "ERROR: {}", err);
-                }
-                Ok(dent) => {
-                    wout!(out, "{}", dent.path().display());
+        } else if args.flag_ignore_errors {
+            for dent in it.filter_map(|e| e.ok()) {
+                wout!(out, "{}", dent.path().display());
+            }
+        } else {
+            for dent in it {
+                match dent {
+                    Err(err) => {
+                        out.flush().unwrap();
+                        wout!(eout, "ERROR: {}", err);
+                    }
+                    Ok(dent) => {
+                        wout!(out, "{}", dent.path().display());
+                    }
                 }
             }
         }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,0 +1,34 @@
+use std::fs::OpenOptions;
+use std::io::Error;
+use std::mem;
+use std::os::windows::fs::OpenOptionsExt;
+use std::os::windows::io::AsRawHandle;
+use std::path::Path;
+
+use winapi::um::fileapi::{
+    BY_HANDLE_FILE_INFORMATION,
+    GetFileInformationByHandle,
+};
+use winapi::um::winbase::FILE_FLAG_BACKUP_SEMANTICS;
+
+/// Return metadata for the file at the given path.
+pub fn windows_file_handle_info<P: AsRef<Path>>(
+    path: P,
+) -> Result<BY_HANDLE_FILE_INFORMATION, Error> {
+    // The FILE_FLAG_BACKUP_SEMANTICS flag is needed to open directories
+    // https://msdn.microsoft.com/en-us/library/windows/desktop/aa365258(v=vs.85).aspx
+    let file = OpenOptions::new()
+        .create(false)
+        .write(false)
+        .read(true)
+        .custom_flags(FILE_FLAG_BACKUP_SEMANTICS)
+        .open(path)?;
+
+    unsafe {
+        let mut info = mem::zeroed();
+        if GetFileInformationByHandle(file.as_raw_handle(), &mut info) == 0 {
+            return Err(Error::last_os_error());
+        }
+        Ok(info)
+    }
+}


### PR DESCRIPTION
This commit includes a new method, `same_file_system`, which when
enabled, will cause walkdir to only descend into directories that are on
the same file system as the root path.

Closes #8, Closes #107

---

While this PR retains the authorship of #107, this ended up requiring significant refactoring:

* Instead of wringing our hands over uncloneable I/O errors, we simply delay the discovery of the root file path's device number until the first call to `next`, and if an error comes up there, we return it and quit iteration. This also eliminates a redundant store of the root file path.
* We make sure walkdir continues to compile on non-Unix/non-Windows platforms. If `same_file_system` is used on an unsupported platform, then an error is returned.
* Fix a bug in the behavior of the program. The common behavior of options like this seems to be to yield the directory that is the root of another file system, but to simply not descend into it. This makes sense, since every entry really belongs to its parent directory, which by induction, is on the same file system as the root. This fixes a critical performance bug as well, in that #107 was making an extra stat call for every entry, but we only need to make it for every directory. This brings the performance of `walkdir -x ./` to par with `find ./ -xdev`.
* Fix a variety of formatting bugaboos.
* Improve the documentation of `same_file_system` as well.