### PR TITLE
Fix bug in `skip_current_dir` 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -778,10 +778,7 @@ impl IntoIter {
     /// [`filter_entry`]: #method.filter_entry
     pub fn skip_current_dir(&mut self) {
         if !self.stack_list.is_empty() {
-            self.stack_list.pop();
-        }
-        if !self.stack_path.is_empty() {
-            self.stack_path.pop();
+            self.pop();
         }
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -471,6 +471,30 @@ fn walk_dir_7() {
     assert_tree_eq!(exp, got);
 }
 
+/// Regression test for #118. `skip_current_dir` sometimes destroyed internal
+/// invariants.
+#[test]
+fn skip_current_dir() {
+    let t = td("foo", vec![
+        td("a", vec![td("a", vec![]), tf("f")]),
+        td("b", vec![]),
+    ]);
+
+    let tmp = tmpdir();
+    t.create_in(tmp.path()).unwrap();
+
+    let mut wd = WalkDir::new(tmp.path()).max_open(1).into_iter();
+    wd.next();
+    wd.next();
+    wd.next();
+    wd.next();
+
+    wd.skip_current_dir();
+    wd.next();
+    wd.skip_current_dir();
+    wd.next();
+}
+
 #[test]
 fn walk_dir_sym_1() {
     let exp = td("foo", vec![tf("bar"), tlf("bar", "baz")]);


### PR DESCRIPTION
Fixes #118 

As discussed in the issue, the fix is fairly straight forward. I even managed to create a fairly minimal example in form of a test. It indeed panics before the patch and works fine afterwards. I used `self.pop()` in `skip_current_dir` as I think it's correct there. As far as I can tell `stack_path` has always the same length as `stack_list` or is empty. So there is no reason to treat them independently.

Regarding the second way the invariant can be destroyed I mentioned [here](https://github.com/BurntSushi/walkdir/issues/118#issuecomment-510065399): I tried to trigger this bug, but it's hard. So I think this can only go wrong when `Ancestor::new` returns an error. This apparently only happens on Windows (which I'm not currently using) and I don't know when exactly this error is triggered. So I will stop now in trying to trigger the bug. So the question is: should I "fix" this what I think is a bug in some situations OR should I just keep it as is?