### PR TITLE
pop path on error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -660,7 +660,14 @@ impl Iterator for IntoIter {
                 .next();
             match next {
                 None => self.pop(),
-                Some(Err(err)) => return Some(Err(err)),
+                Some(Err(err)) => {
+                    // There is an error with this path,
+                    // thus, we need to pop the current
+                    // path or we run the risk of getting
+                    // stuck in a loop.
+                    self.pop();
+                    return Some(Err(err));
+                },
                 Some(Ok(dent)) => {
                     if let Some(result) = self.handle_entry(dent) {
                         return Some(result);


### PR DESCRIPTION
It appears that because the current path is not getting popped on an error, this can result in trying to open the same path when there is an error leading to a infinite loop in certain occasions. This issue was observed here: https://github.com/BurntSushi/walkdir/issues/128