### PR TITLE
Allow end users to construct DirEntry

### DIFF
--- a/src/dent.rs
+++ b/src/dent.rs
@@ -194,7 +194,7 @@ impl DirEntry {
     }
 
     #[cfg(windows)]
-    pub(crate) fn from_entry(
+    pub fn from_entry(
         depth: usize,
         ent: &fs::DirEntry,
     ) -> Result<DirEntry> {
@@ -215,7 +215,7 @@ impl DirEntry {
     }
 
     #[cfg(unix)]
-    pub(crate) fn from_entry(
+    pub fn from_entry(
         depth: usize,
         ent: &fs::DirEntry,
     ) -> Result<DirEntry> {
@@ -234,7 +234,7 @@ impl DirEntry {
     }
 
     #[cfg(not(any(unix, windows)))]
-    pub(crate) fn from_entry(
+    pub fn from_entry(
         depth: usize,
         ent: &fs::DirEntry,
     ) -> Result<DirEntry> {
@@ -250,7 +250,7 @@ impl DirEntry {
     }
 
     #[cfg(windows)]
-    pub(crate) fn from_path(
+    pub fn from_path(
         depth: usize,
         pb: PathBuf,
         follow: bool,
@@ -272,7 +272,7 @@ impl DirEntry {
     }
 
     #[cfg(unix)]
-    pub(crate) fn from_path(
+    pub fn from_path(
         depth: usize,
         pb: PathBuf,
         follow: bool,
@@ -296,7 +296,7 @@ impl DirEntry {
     }
 
     #[cfg(not(any(unix, windows)))]
-    pub(crate) fn from_path(
+    pub fn from_path(
         depth: usize,
         pb: PathBuf,
         follow: bool,


### PR DESCRIPTION
Change pub(crate) to pub for the constructors, so end users can create DirEntries themselves.

I've got a project in which the filter_entry is a crucial part, it also depends on some input parameters. However, I can't write unit tests for the filter functionality, as I can't create DirEntries.

This PR allows the enduser to create DirEntries, in order to be able to construct unit tests for their filter function.