### PR TITLE
Implement `try_filter_entry`

### DIFF
--- a/src/tests/recursive.rs
+++ b/src/tests/recursive.rs
@@ -879,6 +879,45 @@ fn filter_entry() {
 }
 
 #[test]
+fn try_filter_entry() {
+    let dir = Dir::tmp();
+    dir.mkdirp("foo/bar/baz/abc");
+    dir.mkdirp("quux");
+
+    let wd = WalkDir::new(dir.path())
+        .into_iter()
+        .try_filter_entry(|res| matches!(res, Ok(ent) if ent.file_name() != "baz"));
+    let r = dir.run_recursive(wd);
+    r.assert_no_errors();
+
+    let expected = vec![
+        dir.path().to_path_buf(),
+        dir.join("foo"),
+        dir.join("foo").join("bar"),
+        dir.join("quux"),
+    ];
+    assert_eq!(expected, r.sorted_paths());
+}
+
+#[test]
+fn try_filter_entry_skip_error() {
+    let dir = Dir::tmp();
+    dir.symlink_dir("a", "a");
+
+    let wd = WalkDir::new(dir.path())
+        .follow_links(true) // to cause the error
+        .into_iter()
+        .try_filter_entry(|res| res.is_ok());
+    let r = dir.run_recursive(wd);
+    r.assert_no_errors();
+
+    let expected = vec![
+        dir.path().to_path_buf(),
+    ];
+    assert_eq!(expected, r.sorted_paths());
+}
+
+#[test]
 fn sort() {
     let dir = Dir::tmp();
     dir.mkdirp("foo/bar/baz/abc");


### PR DESCRIPTION
I had to add a couple of traits to keep the crate usable, but made sure the user doesn't need to know about them.

It took me a couple of tries to land on the `TryFilterPredicate` trait, here's a breakdown of my thought process, maybe you'll have a better idea:

1. The signature `fn filter_entry<P>(self, predicate: P) -> FilterEntry<Self, P>` has to use `P` in the return type, so the predicate can't just be wrapped like `|res| res.is_err() || predicate(res.unwrap())` otherwise we get an unnameable return type, having to use `-> impl Trait` syntax which would break method chaining.

1. I added the `TryFilterPredicate` trait and tried to implement it for both `FnMut(&DirEntry) -> bool` and `FnMut(&Result<DirEntry>) -> bool`, but the compiler says they're conflicting implementations, I don't understand why and didn't find much on this.

1. So next I tried to add `FilterPredicateAdapter<P: FnMut(&DirEntry) -> bool>` and implement `FnMut(&Result<DirEntry>)` for it but that doesn't seem possible on stable yet.

1. And finally I got it working by implementing `TryFilterPredicate` for `FnMut(&Result<DirEntry>) -> bool`, and for `FilterPredicateAdapter`.
   So now `FilterEntry` is defined as `struct FilterEntry<I, P>(TryFilterEntry<I, FilterPredicateAdapter<P>>)`.

I'm still relatively new to writing rust, so please point out any changes I can make to improve the code, naming, docs, or anything else!