### PR TITLE
Replace "cfg(test)" with "cfg(doctest)" for readme testing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@ for entry in walker.filter_entry(|e| !is_hidden(e)) {
 #![deny(missing_docs)]
 #![allow(unknown_lints)]
 
-#[cfg(test)]
+#[cfg(doctest)]
 doc_comment::doctest!("../README.md");
 
 use std::cmp::{min, Ordering};


### PR DESCRIPTION
Rustdoc now passes "doctest" when running in test mode.