### PR TITLE
iterator: implement `FusedIterator`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,7 @@ use std::cmp::{min, Ordering};
 use std::fmt;
 use std::fs::{self, ReadDir};
 use std::io;
+use std::iter;
 use std::path::{Path, PathBuf};
 use std::result;
 use std::vec;
@@ -940,6 +941,8 @@ impl IntoIter {
     }
 }
 
+impl iter::FusedIterator for IntoIter {}
+
 impl DirList {
     fn close(&mut self) {
         if let DirList::Opened { .. } = *self {
@@ -1020,6 +1023,11 @@ where
             return Some(Ok(dent));
         }
     }
+}
+
+impl<P> iter::FusedIterator for FilterEntry<IntoIter, P> where
+    P: FnMut(&DirEntry) -> bool
+{
 }
 
 impl<P> FilterEntry<IntoIter, P>


### PR DESCRIPTION
`IntoIter` and `FilterEntry<IntoIter, P>` will return `None` once they returned `None`.
Implementing `FusedIterator` allows `Iterator::fuse` method to be optimized.

> Calling next on a fused iterator that has returned `None` once is guaranteed to return `None` again. This trait should be implemented by all iterators that behave this way because it allows optimizing `Iterator::fuse`.
>
> --- <https://doc.rust-lang.org/1.45.2/std/iter/trait.FusedIterator.html>

I checked `next()` implementations lightly and they seem to be already fused.