### PR TITLE
cli switch justfiles for displaying just files like find type f

### DIFF
--- a/src/dent.rs
+++ b/src/dent.rs
@@ -181,7 +181,7 @@ impl DirEntry {
     /// This works around a bug in Rust's standard library:
     /// https://github.com/rust-lang/rust/issues/46484
     #[cfg(windows)]
-    pub(crate) fn is_dir(&self) -> bool {
+    pub fn is_dir(&self) -> bool {
         use std::os::windows::fs::MetadataExt;
         use winapi::um::winnt::FILE_ATTRIBUTE_DIRECTORY;
         self.metadata.file_attributes() & FILE_ATTRIBUTE_DIRECTORY != 0
@@ -189,7 +189,7 @@ impl DirEntry {
 
     /// Returns true if and only if this entry points to a directory.
     #[cfg(not(windows))]
-    pub(crate) fn is_dir(&self) -> bool {
+    pub fn is_dir(&self) -> bool {
         self.ty.is_dir()
     }
 

--- a/walkdir-list/main.rs
+++ b/walkdir-list/main.rs
@@ -119,8 +119,16 @@ where
                 continue;
             }
         };
-        write_path(&mut stdout, dent.path())?;
-        stdout.write_all(b"\n")?;
+
+        if dent.is_dir() {
+            if !args.justfiles {
+                write_path(&mut stdout, dent.path())?;
+                stdout.write_all(b"\n")?;
+            }
+        } else {
+            write_path(&mut stdout, dent.path())?;
+            stdout.write_all(b"\n")?;
+        }
     }
     Ok(())
 }
@@ -145,6 +153,7 @@ where
                 continue;
             }
         };
+
         stdout.write_all("  ".repeat(dent.depth()).as_bytes())?;
         write_os_str(&mut stdout, dent.file_name())?;
         stdout.write_all(b"\n")?;
@@ -166,6 +175,7 @@ struct Args {
     same_file_system: bool,
     timeit: bool,
     count: bool,
+    justfiles: bool,
 }
 
 impl Args {
@@ -243,6 +253,11 @@ impl Args {
                     .short("c")
                     .help("Print only a total count of all file paths."),
             )
+            .arg(Arg::with_name("justfiles")
+                 .long("justfiles")
+                 .short("j")
+                 .help("Print only the file paths like find type f"),
+            )
             .get_matches();
 
         let dirs = match parsed.values_of_os("dirs") {
@@ -262,6 +277,7 @@ impl Args {
             same_file_system: parsed.is_present("same-file-system"),
             timeit: parsed.is_present("timeit"),
             count: parsed.is_present("count"),
+            justfiles: parsed.is_present("justfiles"),
         })
     }
 


### PR DESCRIPTION
Made is_dir() public because it's useful for filtering out directories when we just want to print out files with their full paths.

For the demo walkdir-list too, I added a new clap switch --justfiles to print out only paths of type file  NOT TYPE DIRECTORY.  In other words like the find tool -type f
The equivalent of:
```
find blahdir -type f -print
```
is:
```
walkdir-list --justfiles blahdir
```
or
```
walkdir-list -j blahdir
```
