### PR TITLE
Add convenience functions for sorting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -419,6 +419,19 @@ impl WalkDir {
         self.sort_by(move |a, b| cmp(a).cmp(&cmp(b)))
     }
 
+    /// Sort directory entries by file name, to ensure a deterministic order.
+    ///
+    /// This is a convenience function for calling `Self::sort_by()`.
+    ///
+    /// ```rust,no-run
+    /// use walkdir::WalkDir;
+    ///
+    /// WalkDir::new("foo").sort_by_file_name();
+    /// ```
+    pub fn sort_by_file_name(self) -> Self {
+        self.sort_by(|a, b| a.file_name().cmp(b.file_name()))
+    }
+
     /// Yield a directory's contents before the directory itself. By default,
     /// this is disabled.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,7 +377,7 @@ impl WalkDir {
         self
     }
 
-    /// Set a function for sorting directory entries.
+    /// Set a function for sorting directory entries with a comparator function.
     ///
     /// If a compare function is set, the resulting iterator will return all
     /// paths in sorted order. The compare function will be called to compare
@@ -396,6 +396,27 @@ impl WalkDir {
     {
         self.opts.sorter = Some(Box::new(cmp));
         self
+    }
+
+    /// Set a function for sorting directory entries with a key extraction function.
+    ///
+    /// If a compare function is set, the resulting iterator will return all
+    /// paths in sorted order. The compare function will be called to compare
+    /// entries from the same directory.
+    ///
+    /// ```rust,no-run
+    /// use std::cmp;
+    /// use std::ffi::OsString;
+    /// use walkdir::WalkDir;
+    ///
+    /// WalkDir::new("foo").sort_by_key(|a| a.file_name().to_owned());
+    /// ```
+    pub fn sort_by_key<K, F>(self, mut cmp: F) -> Self
+    where
+        F: FnMut(&DirEntry) -> K + Send + Sync + 'static,
+        K: Ord,
+    {
+        self.sort_by(move |a, b| cmp(a).cmp(&cmp(b)))
     }
 
     /// Yield a directory's contents before the directory itself. By default,

--- a/src/tests/recursive.rs
+++ b/src/tests/recursive.rs
@@ -923,6 +923,27 @@ fn sort_by_key() {
 }
 
 #[test]
+fn sort_by_file_name() {
+    let dir = Dir::tmp();
+    dir.mkdirp("foo/bar/baz/abc");
+    dir.mkdirp("quux");
+
+    let wd = WalkDir::new(dir.path()).sort_by_file_name();
+    let r = dir.run_recursive(wd);
+    r.assert_no_errors();
+
+    let expected = vec![
+        dir.path().to_path_buf(),
+        dir.join("foo"),
+        dir.join("foo").join("bar"),
+        dir.join("foo").join("bar").join("baz"),
+        dir.join("foo").join("bar").join("baz").join("abc"),
+        dir.join("quux"),
+    ];
+    assert_eq!(expected, r.paths());
+}
+
+#[test]
 fn sort_max_open() {
     let dir = Dir::tmp();
     dir.mkdirp("foo/bar/baz/abc");

--- a/src/tests/recursive.rs
+++ b/src/tests/recursive.rs
@@ -879,7 +879,7 @@ fn filter_entry() {
 }
 
 #[test]
-fn sort() {
+fn sort_by() {
     let dir = Dir::tmp();
     dir.mkdirp("foo/bar/baz/abc");
     dir.mkdirp("quux");
@@ -896,6 +896,28 @@ fn sort() {
         dir.join("foo").join("bar"),
         dir.join("foo").join("bar").join("baz"),
         dir.join("foo").join("bar").join("baz").join("abc"),
+    ];
+    assert_eq!(expected, r.paths());
+}
+
+#[test]
+fn sort_by_key() {
+    let dir = Dir::tmp();
+    dir.mkdirp("foo/bar/baz/abc");
+    dir.mkdirp("quux");
+
+    let wd =
+        WalkDir::new(dir.path()).sort_by_key(|a| a.file_name().to_owned());
+    let r = dir.run_recursive(wd);
+    r.assert_no_errors();
+
+    let expected = vec![
+        dir.path().to_path_buf(),
+        dir.join("foo"),
+        dir.join("foo").join("bar"),
+        dir.join("foo").join("bar").join("baz"),
+        dir.join("foo").join("bar").join("baz").join("abc"),
+        dir.join("quux"),
     ];
     assert_eq!(expected, r.paths());
 }


### PR DESCRIPTION
This adds a `sort_by_key()` function like the one in `std`, and a `sort_by_file_name()` function as a convenience for sorting by file name.

My experience with directory walkers in any languages I used so far was that mostly, I either don't care about the order, or I want an order that is deterministic for the same directory content independent from the underlying system. So if I need to sort, its almost always by file name.

This was my initial motivation for adding `sort_by_key`, to make `sort_by(|a, b| a.file_name().cmp(b.file_name()))` easier to write as `sort_by_key(|e| e.file_name())`. However, due to https://github.com/rust-lang/rust/issues/34162, this does not actually compile, so I also added `sort_by_file_name()` for what I perceive as the common case. 

I kept `sort_by_key()` for consistency with `std`, and because there are still valid usecases for it, eg sorting by file size.