### PR TITLE
api: add `From<DirEntry>` implementation for PathBuf

### DIFF
--- a/src/dent.rs
+++ b/src/dent.rs
@@ -357,6 +357,12 @@ impl fmt::Debug for DirEntry {
     }
 }
 
+impl From<DirEntry> for PathBuf {
+    fn from(de: DirEntry) -> Self {
+        de.into_path()
+    }
+}
+
 /// Unix-specific extension methods for `walkdir::DirEntry`
 #[cfg(unix)]
 pub trait DirEntryExt {

--- a/src/dent.rs
+++ b/src/dent.rs
@@ -363,6 +363,12 @@ impl From<DirEntry> for PathBuf {
     }
 }
 
+impl AsRef<Path> for DirEntry {
+    fn as_ref(&self) -> &Path {
+        self.path()
+    }
+}
+
 /// Unix-specific extension methods for `walkdir::DirEntry`
 #[cfg(unix)]
 pub trait DirEntryExt {


### PR DESCRIPTION
Adds support for `PathBuf::from(DirEntry)` and `DirEntry::into()` for `PathBuf`.