### PR TITLE
Promote `or_default` idiom for checking file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ use walkdir::{DirEntry, WalkDir};
 fn is_hidden(entry: &DirEntry) -> bool {
     entry.file_name()
          .to_str()
-         .map(|s| s.starts_with("."))
-         .unwrap_or(false)
+         .unwrap_or_default()
+         .starts_with(".")
 }
 
 let walker = WalkDir::new("foo").into_iter();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,8 +87,8 @@ use walkdir::{DirEntry, WalkDir};
 fn is_hidden(entry: &DirEntry) -> bool {
     entry.file_name()
          .to_str()
-         .map(|s| s.starts_with("."))
-         .unwrap_or(false)
+         .unwrap_or_default()
+         .starts_with(".")
 }
 
 # fn try_main() -> Result<(), Error> {


### PR DESCRIPTION
Not sure how you'd feel about it, but decided to PR just in case!

`unwrap_or_default()` feels somewhat easier to read than `.map` and
`.unwrap_or_false`. It doesn't make a big difference here, but we can
use an opportunity to teach folks that this idiom exists.

Note that both version work incorrectly for non-utf8 file names, which
is unfortunate, but isn't something we can do anything about in the
example.