### PR TITLE
Port from winapi to windows-sys.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = ["walkdir-list"]
 same-file = "1.0.1"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.36.0"
+version = "0.42.0"
 features = [
     "Win32_Storage_FileSystem",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,11 @@ members = ["walkdir-list"]
 [dependencies]
 same-file = "1.0.1"
 
-[target.'cfg(windows)'.dependencies.winapi]
-version = "0.3"
-features = ["std", "winnt"]
+[target.'cfg(windows)'.dependencies.windows-sys]
+version = "0.36.0"
+features = [
+    "Win32_Storage_FileSystem",
+]
 
 [target.'cfg(windows)'.dependencies.winapi-util]
 version = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ members = ["walkdir-list"]
 same-file = "1.0.1"
 
 [target.'cfg(windows)'.dependencies.windows-sys]
-version = "0.42.0"
+version = "0.45.0"
 features = [
     "Win32_Storage_FileSystem",
 ]

--- a/src/dent.rs
+++ b/src/dent.rs
@@ -183,7 +183,7 @@ impl DirEntry {
     #[cfg(windows)]
     pub(crate) fn is_dir(&self) -> bool {
         use std::os::windows::fs::MetadataExt;
-        use winapi::um::winnt::FILE_ATTRIBUTE_DIRECTORY;
+        use windows_sys::Win32::Storage::FileSystem::FILE_ATTRIBUTE_DIRECTORY;
         self.metadata.file_attributes() & FILE_ATTRIBUTE_DIRECTORY != 0
     }
 


### PR DESCRIPTION
walkdir just uses the Windows bindings for one thing, and the change is
straightforward.

This accompanies https://github.com/BurntSushi/winapi-util/pull/13.
