### PR TITLE
tests: add contents_first with min & max depth

### DIFF
--- a/src/tests/recursive.rs
+++ b/src/tests/recursive.rs
@@ -791,7 +791,7 @@ fn min_depth_1() {
     r.assert_no_errors();
 
     let expected = vec![dir.join("a"), dir.join("a").join("b")];
-    assert_eq!(expected, r.sorted_paths());
+    assert_eq!(expected, r.paths());
 }
 
 #[test]
@@ -804,7 +804,7 @@ fn min_depth_2() {
     r.assert_no_errors();
 
     let expected = vec![dir.join("a").join("b")];
-    assert_eq!(expected, r.sorted_paths());
+    assert_eq!(expected, r.paths());
 }
 
 #[test]
@@ -817,7 +817,7 @@ fn max_depth_0() {
     r.assert_no_errors();
 
     let expected = vec![dir.path().to_path_buf()];
-    assert_eq!(expected, r.sorted_paths());
+    assert_eq!(expected, r.paths());
 }
 
 #[test]
@@ -830,7 +830,7 @@ fn max_depth_1() {
     r.assert_no_errors();
 
     let expected = vec![dir.path().to_path_buf(), dir.join("a")];
-    assert_eq!(expected, r.sorted_paths());
+    assert_eq!(expected, r.paths());
 }
 
 #[test]
@@ -844,7 +844,7 @@ fn max_depth_2() {
 
     let expected =
         vec![dir.path().to_path_buf(), dir.join("a"), dir.join("a").join("b")];
-    assert_eq!(expected, r.sorted_paths());
+    assert_eq!(expected, r.paths());
 }
 
 // FIXME: This test seems wrong. It should return nothing!
@@ -858,7 +858,7 @@ fn min_max_depth_diff_nada() {
     r.assert_no_errors();
 
     let expected = vec![dir.join("a").join("b").join("c")];
-    assert_eq!(expected, r.sorted_paths());
+    assert_eq!(expected, r.paths());
 }
 
 #[test]
@@ -871,7 +871,7 @@ fn min_max_depth_diff_0() {
     r.assert_no_errors();
 
     let expected = vec![dir.join("a").join("b")];
-    assert_eq!(expected, r.sorted_paths());
+    assert_eq!(expected, r.paths());
 }
 
 #[test]
@@ -884,7 +884,122 @@ fn min_max_depth_diff_1() {
     r.assert_no_errors();
 
     let expected = vec![dir.join("a"), dir.join("a").join("b")];
-    assert_eq!(expected, r.sorted_paths());
+    assert_eq!(expected, r.paths());
+}
+
+#[test]
+fn contents_first_min_depth_1() {
+    let dir = Dir::tmp();
+    dir.mkdirp("a/b");
+
+    let wd = WalkDir::new(dir.path()).contents_first(true).min_depth(1);
+    let r = dir.run_recursive(wd);
+    r.assert_no_errors();
+
+    let expected = vec![dir.join("a").join("b"), dir.join("a")];
+    assert_eq!(expected, r.paths());
+}
+
+#[test]
+fn contents_first_min_depth_2() {
+    let dir = Dir::tmp();
+    dir.mkdirp("a/b");
+
+    let wd = WalkDir::new(dir.path()).contents_first(true).min_depth(2);
+    let r = dir.run_recursive(wd);
+    r.assert_no_errors();
+
+    let expected = vec![dir.join("a").join("b")];
+    assert_eq!(expected, r.paths());
+}
+
+#[test]
+fn contents_first_max_depth_0() {
+    let dir = Dir::tmp();
+    dir.mkdirp("a/b");
+
+    let wd = WalkDir::new(dir.path()).contents_first(true).max_depth(0);
+    let r = dir.run_recursive(wd);
+    r.assert_no_errors();
+
+    let expected = vec![dir.path().to_path_buf()];
+    assert_eq!(expected, r.paths());
+}
+
+#[test]
+fn contents_first_max_depth_1() {
+    let dir = Dir::tmp();
+    dir.mkdirp("a/b");
+
+    let wd = WalkDir::new(dir.path()).contents_first(true).max_depth(1);
+    let r = dir.run_recursive(wd);
+    r.assert_no_errors();
+
+    let expected = vec![dir.join("a"), dir.path().to_path_buf()];
+    assert_eq!(expected, r.paths());
+}
+
+#[test]
+fn contents_first_max_depth_2() {
+    let dir = Dir::tmp();
+    dir.mkdirp("a/b");
+
+    let wd = WalkDir::new(dir.path()).contents_first(true).max_depth(2);
+    let r = dir.run_recursive(wd);
+    r.assert_no_errors();
+
+    let expected =
+        vec![dir.join("a").join("b"), dir.join("a"), dir.path().to_path_buf()];
+    assert_eq!(expected, r.paths());
+}
+
+// FIXME: This test seems wrong. It should return nothing!
+#[test]
+fn contents_first_min_max_depth_diff_nada() {
+    let dir = Dir::tmp();
+    dir.mkdirp("a/b/c");
+
+    let wd = WalkDir::new(dir.path())
+        .contents_first(true)
+        .min_depth(3)
+        .max_depth(2);
+    let r = dir.run_recursive(wd);
+    r.assert_no_errors();
+
+    let expected = vec![dir.join("a").join("b").join("c")];
+    assert_eq!(expected, r.paths());
+}
+
+#[test]
+fn contents_first_min_max_depth_diff_0() {
+    let dir = Dir::tmp();
+    dir.mkdirp("a/b/c");
+
+    let wd = WalkDir::new(dir.path())
+        .contents_first(true)
+        .min_depth(2)
+        .max_depth(2);
+    let r = dir.run_recursive(wd);
+    r.assert_no_errors();
+
+    let expected = vec![dir.join("a").join("b")];
+    assert_eq!(expected, r.paths());
+}
+
+#[test]
+fn contents_first_min_max_depth_diff_1() {
+    let dir = Dir::tmp();
+    dir.mkdirp("a/b/c");
+
+    let wd = WalkDir::new(dir.path())
+        .contents_first(true)
+        .min_depth(1)
+        .max_depth(2);
+    let r = dir.run_recursive(wd);
+    r.assert_no_errors();
+
+    let expected = vec![dir.join("a").join("b"), dir.join("a")];
+    assert_eq!(expected, r.paths());
 }
 
 #[test]


### PR DESCRIPTION
This just adds `contents_first(true)` versions of the existing tests for min and max depth. Given that handling contents first can be a bit confusing, it seemed wise to test it more thoroughly.

For symmetry, this switches the existing min and max depth tests to use `path()` instead of `sorted_paths()`. Because all of the test directories only have one entry, there should never be an issue with entries being returned in a different, but still correct, order.

---

This isn’t strictly necessary, but when I was working on #163 I was concerned that min and max depth might break with `contents_first`. No worries if you’d prefer not to add these, or if you’d prefer to keep `sorted_paths()`.