### PR TITLE
Doc correction

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -714,7 +714,7 @@ impl Iterator for IntoIter {
 impl IntoIter {
     /// Skips the current directory.
     ///
-    /// This causes the iterator to stop traversing the contents of the least
+    /// This causes the iterator to stop traversing the contents of the most
     /// recently yielded directory. This means any remaining entries in that
     /// directory will be skipped (including sub-directories).
     ///


### PR DESCRIPTION
It seems to me that the original sentence doesn't makes sense, i.e. the least-recently-yielded directory will always be the root of the tree being iterated! Am I missing something?