### PR TITLE
Add `AsRef<std::path::Path>` for `DirEntry`

### DIFF
--- a/src/dent.rs
+++ b/src/dent.rs
@@ -294,6 +294,12 @@ impl DirEntry {
     }
 }
 
+impl AsRef<Path> for DirEntry {
+    fn as_ref(&self) -> &Path {
+        self.path()
+    }
+}
+
 impl Clone for DirEntry {
     #[cfg(windows)]
     fn clone(&self) -> DirEntry {


### PR DESCRIPTION
I was working on another project with a function roughly like this

```rs
fn foo<I, P>(iter: I) -> Bar
where
    P: AsRef<std::path::Path>,
    I: IntoIterator<Item = P>,
{
    // implementation goes here
}
```

Somewhere else I tried calling this function with an iterator of `DirEntry`s
```rust
foo(iter_of_entries)
```

This does not work, because `DirEntry` does not implement `AsRef<Path>`, but `Path` does. So I tried this

```rust
let mapped = iter_of_entries.map(DirEntry::path);
foo(mapped);
```

This does not compile, because `DirEntry::path()` returns a reference to the entry, which does not exist after the `map`
The thing that works is this

```rust
let owned_entries: Vec<_> = iter_of_entries.collect();
let mapped = owned_entries.iter().map(DirEntry::path);
foo(mapped);
```

It works, because the entries are now collected in a `Vec` and the closure's argument is already a reference. This is suboptimal, because it requires the user to allocate a vector that is used exactly once to call a function that doesn't want a `Vec`.