### PR TITLE
Fixup manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 keywords = ["directory", "recursive", "walk", "iterator"]
 categories = ["filesystem"]
 license = "Unlicense/MIT"
-exclude = [".github", "compare", "walkdir-list"]
+exclude = [".github", "compare"]
 edition = "2018"
 
 [workspace]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,12 +10,8 @@ readme = "README.md"
 keywords = ["directory", "recursive", "walk", "iterator"]
 categories = ["filesystem"]
 license = "Unlicense/MIT"
-exclude = ["/ci/*", "/.travis.yml", "/appveyor.yml"]
+exclude = [".github", "compare", "walkdir-list"]
 edition = "2018"
-
-[badges]
-travis-ci = { repository = "BurntSushi/walkdir" }
-appveyor = { repository = "BurntSushi/walkdir" }
 
 [workspace]
 members = ["walkdir-list"]


### PR DESCRIPTION
This changes the exclusion patterns in the manifest to reflect the current status of CI (appveyor/travis -> github), as well as remove the contents of the compare directory since those are for only for benchmarking purposes and irrelevant to downstream users.

Related: #155 