### PR TITLE
Remove Unnecessary 'fs' Prefix from FileType

### DIFF
--- a/src/dent.rs
+++ b/src/dent.rs
@@ -155,7 +155,7 @@ impl DirEntry {
     /// This never makes any system calls.
     ///
     /// [`follow_links`]: struct.WalkDir.html#method.follow_links
-    pub fn file_type(&self) -> fs::FileType {
+    pub fn file_type(&self) -> FileType {
         self.ty
     }
 


### PR DESCRIPTION
Hello! I only modified **line 158** of **src/dent.rs**. I noticed that `FileType` has an `fs` prefix, which is probably unnecessary as `FileType` is already imported by `include std::fs::{self, FileType}`. On line 42, `FileType` is used without specifying `fs`.

The crate builds and all tests seem to pass. I apologize if I overlooked some kind of contribution requirement - please let me know what I'm missing and I'll address it 🙂