### PR TITLE
feat: support asynchronous filtering

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,12 @@ appveyor = { repository = "BurntSushi/walkdir" }
 members = ["walkdir-list"]
 
 [dependencies]
+futures = { version = "0.3.30", optional = true }
 same-file = "1.0.1"
+
+[features]
+default = []
+async = ["dep:futures"]
 
 [target.'cfg(windows)'.dependencies.winapi-util]
 version = "0.1.1"


### PR DESCRIPTION
Sometimes, we would like to suspend the execution to take the time to find out if we would want to accept this directory entry or not.

This is a simple attempt to support asynchronous filtering in the context of the tree walking.