### PR TITLE
Fix: filter_entry misbehaves when contents_first is enabled

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -784,6 +784,16 @@ impl IntoIter {
         }
     }
 
+    // Skips the current directory unless the `contents_first` flag is set.
+    //
+    // `FilterEntry::next` calls this method when a directory does not
+    // satisfy the predicate. See `FilterEntry::next` for more details.
+    fn skip_current_dir_unless_contents_first(&mut self) {
+        if !self.opts.contents_first {
+            self.skip_current_dir();
+        }
+    }
+
     /// Yields only entries which satisfy the given predicate and skips
     /// descending into directories that do not satisfy the given predicate.
     ///
@@ -1077,7 +1087,11 @@ where
             };
             if !(self.predicate)(&dent) {
                 if dent.is_dir() {
-                    self.it.skip_current_dir();
+                    // we cannot call `skip_current_dir` here because it
+                    // will pop the entry iterator for the next directory
+                    // instead of the one corresponding to `dent` if
+                    // `contents_first` is enabled.
+                    self.it.skip_current_dir_unless_contents_first();
                 }
                 continue;
             }

--- a/src/tests/recursive.rs
+++ b/src/tests/recursive.rs
@@ -948,6 +948,33 @@ fn filter_entry() {
 }
 
 #[test]
+fn filter_entry_contents_first() {
+    let dir = Dir::tmp();
+    dir.mkdirp("foo/bar/baz1/abc");
+    dir.mkdirp("foo/bar/baz2/abc");
+    dir.mkdirp("quux");
+
+    let wd = WalkDir::new(dir.path())
+        .contents_first(true)
+        .into_iter()
+        .filter_entry(|ent| {
+            ent.file_name() != "baz1" && ent.file_name() != "baz2"
+        });
+    let r = dir.run_recursive(wd);
+    r.assert_no_errors();
+
+    let expected = vec![
+        dir.path().to_path_buf(),
+        dir.join("foo"),
+        dir.join("foo").join("bar"),
+        dir.join("foo").join("bar").join("baz1").join("abc"),
+        dir.join("foo").join("bar").join("baz2").join("abc"),
+        dir.join("quux"),
+    ];
+    assert_eq!(expected, r.sorted_paths());
+}
+
+#[test]
 fn sort_by() {
     let dir = Dir::tmp();
     dir.mkdirp("foo/bar/baz/abc");


### PR DESCRIPTION
- fixes #171

### Proposed changes

- Introduce a new private method `IntoIter::skip_current_dir_unless_contents_first`
- Make `FilterEntry::next` call `skip_current_dir_unless_contents_first` instead of `skip_current_dir` if the skipped entry is a directory
- Add a test case that tests the combination of `filter_entry` and `contents_first`

### Details

The documentation of `IntoIter::filter_entry` states that:
> Note that if the iterator has `contents_first` enabled, then this method is no different than calling the standard `Iterator::filter` method (because directory entries are yielded after they’ve been descended into).

However, if `contents_first` was enabled and some directories were filtered out, unexpected entries may have been skipped regardless of the `filter_entry` results. Please refer to #171 for an example.

`FilterEntry::next` used to call `skip_current_dir` when the filtered out entry was a directory to stop reading the filtered out directory. `skip_current_dir` realizes this by popping the last `DirList` from `stack_list`. Unfortunately, if `contents_first` was enabled, `skip_current_dir` popped a wrong `DirList` from `stack_list`, because the `DirList` of the filtered out directory had already been removed from `stack_list`.

We should not update `stack_list` if `contents_first` is enabled. So I introduced `skip_current_dir_unless_contents_first` which does nothing if `contents_first` is enabled, otherwise calls `skip_current_dir`.