### PR TITLE
chore(docs): change single character pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ use walkdir::{DirEntry, WalkDir};
 fn is_hidden(entry: &DirEntry) -> bool {
     entry.file_name()
          .to_str()
-         .map(|s| s.starts_with("."))
+         .map(|s| s.starts_with('.'))
          .unwrap_or(false)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ use walkdir::{DirEntry, WalkDir};
 fn is_hidden(entry: &DirEntry) -> bool {
     entry.file_name()
          .to_str()
-         .map(|s| s.starts_with("."))
+         .map(|s| s.starts_with('.'))
          .unwrap_or(false)
 }
 
@@ -752,7 +752,7 @@ impl IntoIter {
     /// fn is_hidden(entry: &DirEntry) -> bool {
     ///     entry.file_name()
     ///          .to_str()
-    ///          .map(|s| s.starts_with("."))
+    ///          .map(|s| s.starts_with('.'))
     ///          .unwrap_or(false)
     /// }
     ///
@@ -802,7 +802,7 @@ impl IntoIter {
     /// fn is_hidden(entry: &DirEntry) -> bool {
     ///     entry.file_name()
     ///          .to_str()
-    ///          .map(|s| s.starts_with("."))
+    ///          .map(|s| s.starts_with('.'))
     ///          .unwrap_or(false)
     /// }
     ///
@@ -1113,7 +1113,7 @@ where
     /// fn is_hidden(entry: &DirEntry) -> bool {
     ///     entry.file_name()
     ///          .to_str()
-    ///          .map(|s| s.starts_with("."))
+    ///          .map(|s| s.starts_with('.'))
     ///          .unwrap_or(false)
     /// }
     ///
@@ -1162,7 +1162,7 @@ where
     /// fn is_hidden(entry: &DirEntry) -> bool {
     ///     entry.file_name()
     ///          .to_str()
-    ///          .map(|s| s.starts_with("."))
+    ///          .map(|s| s.starts_with('.'))
     ///          .unwrap_or(false)
     /// }
     ///


### PR DESCRIPTION
Change the single character string to a char in the examples and README to fix the "clippy::single-char-pattern" warning.