### PR TITLE
Add support for WASI

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,6 +105,9 @@ for entry in walker.filter_entry(|e| !is_hidden(e)) {
 
 #![deny(missing_docs)]
 #![allow(unknown_lints)]
+// https://github.com/rust-lang/rust/issues/130323
+#![cfg_attr(all(target_os = "wasi", target_env = "p2"), feature(wasip2))]
+#![cfg_attr(target_os = "wasi", feature(wasi_ext))]
 
 #[cfg(doctest)]
 doc_comment::doctest!("../README.md");
@@ -121,7 +124,7 @@ use std::vec;
 use same_file::Handle;
 
 pub use crate::dent::DirEntry;
-#[cfg(unix)]
+#[cfg(any(unix, target_os = "wasi"))]
 pub use crate::dent::DirEntryExt;
 pub use crate::error::Error;
 

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -160,6 +160,12 @@ impl Dir {
             symlink(src, link_name)
         }
 
+        #[cfg(target_os = "wasi")]
+        fn imp(src: &Path, link_name: &Path) -> io::Result<()> {
+            use std::os::wasi::fs::symlink_path;
+            symlink_path(src, link_name)
+        }
+
         let (src, link_name) = (self.join(src), self.join(link_name));
         imp(&src, &link_name)
             .map_err(|e| {
@@ -189,6 +195,12 @@ impl Dir {
         fn imp(src: &Path, link_name: &Path) -> io::Result<()> {
             use std::os::unix::fs::symlink;
             symlink(src, link_name)
+        }
+
+        #[cfg(target_os = "wasi")]
+        fn imp(src: &Path, link_name: &Path) -> io::Result<()> {
+            use std::os::wasi::fs::symlink_path;
+            symlink_path(src, link_name)
         }
 
         let (src, link_name) = (self.join(src), self.join(link_name));


### PR DESCRIPTION
Add the magic `feature()` code to allow compiling under wasip2, and expose `ino` and `DirEntryExt`.

Tested with `cargo +nightly build --target wasm32-wasip2`.