### PR TITLE
Add nextest config to work around TempDir incompatibility.

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,4 @@
+[profile.default]
+# By default Nextest runs a process per-test, which causes a race
+# condition in util::TempDir.
+test-threads = 1


### PR DESCRIPTION
Nextest runs a process per test, which causes the atomic int in TempDir to overlap. This PR adds a basic override to the nextest config to use the standard Rust test behaviour.

There are some other more general ways of dealing with this, but this seems least intrusive.