### PR TITLE
feat: DirEntry::has_file_extension() and has_file_name()

### DIFF
--- a/src/dent.rs
+++ b/src/dent.rs
@@ -176,6 +176,22 @@ impl DirEntry {
         self.depth
     }
 
+    /// Returns `true` if this entry is a file and has the `extension` (i.e. "rs" in main.rs).
+    ///
+    /// `let found = matches!(result, Ok(entry) if entry.has_file_extension("rs"));`
+    pub fn has_file_extension(&self, extension: &str) -> bool {
+        self.file_type().is_file()
+            && matches!(self.path.extension(), Some(e) if e == extension)
+    }
+
+    /// Returns `true` if this entry is a file and has the `name` (i.e. "main.rs").
+    ///
+    /// `let found = matches!(result, Ok(entry) if entry.has_file_name("main.rs"));`
+    pub fn has_file_name(&self, name: &str) -> bool {
+        self.file_type().is_file()
+            && matches!(self.path.file_name(), Some(n) if n == name)
+    }
+
     /// Returns true if and only if this entry points to a directory.
     pub(crate) fn is_dir(&self) -> bool {
         self.ty.is_dir()

--- a/src/tests/recursive.rs
+++ b/src/tests/recursive.rs
@@ -1035,6 +1035,32 @@ fn sort_max_open() {
     assert_eq!(expected, r.paths());
 }
 
+#[test]
+fn has_file_extension() {
+    let dir = Dir::tmp();
+    dir.touch("a.file");
+    dir.mkdirp("b.dir");
+
+    let wd = WalkDir::new(dir.path());
+    let ents = dir.run_recursive(wd).sorted_ents();
+
+    assert!(ents[1].has_file_extension("file"));
+    assert_eq!(false, ents[2].has_file_extension("dir"));
+}
+
+#[test]
+fn has_file_name() {
+    let dir = Dir::tmp();
+    dir.touch("a.file");
+    dir.mkdirp("b.dir");
+
+    let wd = WalkDir::new(dir.path());
+    let ents = dir.run_recursive(wd).sorted_ents();
+
+    assert!(ents[1].has_file_name("a.file"));
+    assert_eq!(false, ents[2].has_file_name("b.dir"));
+}
+
 #[cfg(target_os = "linux")]
 #[test]
 fn same_file_system() {


### PR DESCRIPTION
### Features
- Add `DirEntry::has_file_extension()`
- Add `DirEntry::has_file_name()`

### Examples
```rust
result
    .ok()
    .filter(|entry| {
        entry.file_type().is_file()
            && entry.path().extension().is_some_and(|ext| ext == "rs")
    })
```
becomes
```rust
result
    .ok()
    .filter(|entry| entry.has_file_extension("rs"))
```