### PR TITLE
include parent directory path on mid-iteration errors

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,7 @@ use std::io;
 use std::iter;
 use std::path::{Path, PathBuf};
 use std::result;
+use std::sync::Arc;
 use std::vec;
 
 use same_file::Handle;
@@ -669,7 +670,14 @@ enum DirList {
     ///
     /// [`fs::read_dir`]: https://doc.rust-lang.org/stable/std/fs/fn.read_dir.html
     /// [`Option<...>`]: https://doc.rust-lang.org/stable/std/option/enum.Option.html
-    Opened { depth: usize, it: result::Result<ReadDir, Option<Error>> },
+    Opened {
+        depth: usize,
+        /// The path of the directory whose entries are being read. Held so
+        /// that errors yielded mid-iteration can carry the parent path,
+        /// rather than being `Io { path: None, ... }`. See #126.
+        path: Arc<PathBuf>,
+        it: result::Result<ReadDir, Option<Error>>,
+    },
     /// A closed handle.
     ///
     /// All remaining directory entries are read into memory.
@@ -906,10 +914,11 @@ impl IntoIter {
             self.stack_list[self.oldest_opened].close();
         }
         // Open a handle to reading the directory's entries.
-        let rd = fs::read_dir(dent.path()).map_err(|err| {
-            Some(Error::from_path(self.depth, dent.path().to_path_buf(), err))
+        let path = Arc::new(dent.path().to_path_buf());
+        let rd = fs::read_dir(path.as_ref().as_path()).map_err(|err| {
+            Some(Error::from_path(self.depth, (*path).clone(), err))
         });
-        let mut list = DirList::Opened { depth: self.depth, it: rd };
+        let mut list = DirList::Opened { depth: self.depth, path, it: rd };
         if let Some(ref mut cmp) = self.opts.sorter {
             let mut entries: Vec<_> = list.collect();
             entries.sort_by(|a, b| match (a, b) {
@@ -1019,11 +1028,13 @@ impl Iterator for DirList {
     fn next(&mut self) -> Option<Result<DirEntry>> {
         match *self {
             DirList::Closed(ref mut it) => it.next(),
-            DirList::Opened { depth, ref mut it } => match *it {
+            DirList::Opened { depth, ref path, ref mut it } => match *it {
                 Err(ref mut err) => err.take().map(Err),
                 Ok(ref mut rd) => rd.next().map(|r| match r {
                     Ok(r) => DirEntry::from_entry(depth + 1, &r),
-                    Err(err) => Err(Error::from_io(depth + 1, err)),
+                    Err(err) => {
+                        Err(Error::from_path(depth + 1, (**path).clone(), err))
+                    }
                 }),
             },
         }


### PR DESCRIPTION
Closes #126.

When `fs::read_dir` succeeds but iterating an individual entry fails (e.g. on Windows where a directory becomes inaccessible during the walk), `DirList::Opened` was yielding `Error::from_io`, which has `path: None`. Reporters of #126 saw output like:

```
Error { depth: 2, inner: Io { path: None, err: Os { code: 5, kind: PermissionDenied, ... } } }
```

…with no way to tell which directory the error came from beyond the depth.

This stores the directory's path on the `Opened` variant (as an `Arc<PathBuf>` so we don't clone it per successful entry) and uses `Error::from_path` on per-entry errors, so the parent directory now surfaces in `Error::path()`. The case where `fs::read_dir` itself fails already used `from_path`, so this just extends the same behavior to errors yielded mid-iteration.