### PR TITLE
Allow FilterEntry::filter_entry to accept a different predicate type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1057,8 +1057,44 @@ pub struct FilterEntry<I, P> {
     predicate: P,
 }
 
-impl<P> Iterator for FilterEntry<IntoIter, P>
+/// A sealed trait for iterators that support skipping the current directory.
+///
+/// This trait is implemented by [`IntoIter`] and [`FilterEntry`], and is used
+/// as a bound on the inner iterator `I` in a blanket [`Iterator`] impl for
+/// `FilterEntry<I, P>`. This allows chaining multiple [`filter_entry`] calls
+/// with different predicate types.
+///
+/// [`IntoIter`]: struct.IntoIter.html
+/// [`FilterEntry`]: struct.FilterEntry.html
+/// [`filter_entry`]: struct.IntoIter.html#method.filter_entry
+pub trait SkipCurrentDir: Iterator<Item = Result<DirEntry>> {
+    /// Skips the current directory.
+    ///
+    /// This causes the iterator to stop traversing the contents of the least
+    /// recently yielded directory. This means any remaining entries in that
+    /// directory will be skipped (including sub-directories).
+    fn skip_current_dir(&mut self);
+}
+
+impl SkipCurrentDir for IntoIter {
+    fn skip_current_dir(&mut self) {
+        IntoIter::skip_current_dir(self);
+    }
+}
+
+impl<I, P> SkipCurrentDir for FilterEntry<I, P>
 where
+    I: SkipCurrentDir,
+    P: FnMut(&DirEntry) -> bool,
+{
+    fn skip_current_dir(&mut self) {
+        self.it.skip_current_dir();
+    }
+}
+
+impl<I, P> Iterator for FilterEntry<I, P>
+where
+    I: SkipCurrentDir,
     P: FnMut(&DirEntry) -> bool,
 {
     type Item = Result<DirEntry>;
@@ -1086,13 +1122,16 @@ where
     }
 }
 
-impl<P> iter::FusedIterator for FilterEntry<IntoIter, P> where
-    P: FnMut(&DirEntry) -> bool
+impl<I, P> iter::FusedIterator for FilterEntry<I, P>
+where
+    I: SkipCurrentDir + iter::FusedIterator,
+    P: FnMut(&DirEntry) -> bool,
 {
 }
 
-impl<P> FilterEntry<IntoIter, P>
+impl<I, P> FilterEntry<I, P>
 where
+    I: SkipCurrentDir,
     P: FnMut(&DirEntry) -> bool,
 {
     /// Yields only entries which satisfy the given predicate and skips
@@ -1141,7 +1180,10 @@ where
     /// [`skip_current_dir`]: #method.skip_current_dir
     /// [`min_depth`]: struct.WalkDir.html#method.min_depth
     /// [`max_depth`]: struct.WalkDir.html#method.max_depth
-    pub fn filter_entry(self, predicate: P) -> FilterEntry<Self, P> {
+    pub fn filter_entry<Q>(self, predicate: Q) -> FilterEntry<Self, Q>
+    where
+        Q: FnMut(&DirEntry) -> bool,
+    {
         FilterEntry { it: self, predicate }
     }
 

--- a/src/tests/recursive.rs
+++ b/src/tests/recursive.rs
@@ -948,6 +948,37 @@ fn filter_entry() {
 }
 
 #[test]
+fn filter_entry_chained() {
+    // Regression test for https://github.com/BurntSushi/walkdir/issues/130.
+    //
+    // FilterEntry::filter_entry previously required both predicates to be the
+    // same type, making it impossible to chain two different closures.
+    let dir = Dir::tmp();
+    dir.mkdirp("foo/bar/baz");
+    dir.mkdirp("quux/hidden");
+    dir.mkdirp("secret");
+
+    // Chain two filter_entry calls with distinct closure types.
+    // First filter: exclude "hidden" directories.
+    // Second filter: exclude "secret" directories.
+    let wd = WalkDir::new(dir.path())
+        .into_iter()
+        .filter_entry(|ent| ent.file_name() != "hidden")
+        .filter_entry(|ent| ent.file_name() != "secret");
+    let r = dir.run_recursive(wd);
+    r.assert_no_errors();
+
+    let expected = vec![
+        dir.path().to_path_buf(),
+        dir.join("foo"),
+        dir.join("foo").join("bar"),
+        dir.join("foo").join("bar").join("baz"),
+        dir.join("quux"),
+    ];
+    assert_eq!(expected, r.sorted_paths());
+}
+
+#[test]
 fn sort_by() {
     let dir = Dir::tmp();
     dir.mkdirp("foo/bar/baz/abc");


### PR DESCRIPTION
Fixes #130.

## Bug

`FilterEntry<I, P>::filter_entry` accepted a new predicate of exactly
the same type `P` as the one already stored in the `FilterEntry`. Since
every Rust closure has a unique, anonymous type, this made it impossible
to chain two `filter_entry` calls with two different closures:

```rust
// error: expected closure [...], found a different closure
WalkDir::new(.)
    .into_iter()
    .filter_entry(|e| e.file_name() != foo)   // predicate type P1
    .filter_entry(|e| e.file_name() != bar)   // predicate type P2 -- rejected
```

Users were forced to combine the two predicates into one, or use boxed
closures / function pointers.

The second comment in #130 shows the confusing compiler error this
produces in practice.

## Fix

Introduced a public `SkipCurrentDir` trait that abstracts the
`skip_current_dir` capability shared by `IntoIter` and `FilterEntry`.
Then:

- The `Iterator` impl for `FilterEntry<I, P>` is generalized to work
  for any `I: SkipCurrentDir` instead of only `IntoIter`.
- `FilterEntry::filter_entry` now introduces a fresh type parameter `Q`
  for the new predicate, returning `FilterEntry<Self, Q>`, matching the
  signature of `IntoIter::filter_entry`.

This is a minor semver-compatible addition (new public trait
`SkipCurrentDir`). The only theoretical breakage is using an empty
turbofish on `FilterEntry::filter_entry::<>` to observe the former lack
of type parameters, which is not a realistic usage pattern.

## Test

Added `filter_entry_chained` in `src/tests/recursive.rs` that chains
two `filter_entry` calls with distinct closure types and verifies that
both predicates are applied correctly.