### PR TITLE
Fix traversal beyond PATH_MAX

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,18 +21,31 @@ appveyor = { repository = "BurntSushi/walkdir" }
 members = ["walkdir-list"]
 
 [dependencies]
-cap-std = { version = "4.0.2", default-features = false }
+cap-std = { version = "1.0.15", default-features = false }
 same-file = "1.0.1"
 
 [target.'cfg(not(windows))'.dependencies.rustix]
-# cap-std's dependency tree still permits old rustix 0.38 releases under
-# minimal-versions. rustix 0.38.0 does not build on current nightly.
-version = "0.38.44"
+# cap-std's dependency tree still permits old rustix 0.37 releases under
+# minimal-versions. Pin a current patch release for current nightly.
+version = "0.37.28"
 default-features = false
+
+[target.'cfg(not(windows))'.dependencies.fs-set-times]
+# cap-primitives permits fs-set-times 0.19.2, which moved to rustix 0.38
+# and raises the effective MSRV above walkdir's Rust 1.60 floor.
+version = "=0.19.1"
+
+[target.'cfg(not(windows))'.dependencies.itoa]
+# rustix 0.37 permits newer itoa patch releases whose MSRV is above Rust 1.60.
+version = "=1.0.15"
+
+[target.'cfg(not(windows))'.dependencies.libc]
+# rustix and io-lifetimes permit newer libc patch releases whose MSRV is
+# above Rust 1.60.
+version = "=0.2.155"
 
 [target.'cfg(windows)'.dependencies.winapi-util]
 version = "0.1.1"
 
 [dev-dependencies]
 doc-comment = "0.3"
-libc = "0.2.186"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ same-file = "1.0.1"
 # minimal-versions. Pin a current patch release for current nightly.
 version = "0.37.28"
 default-features = false
+features = ["use-libc"]
 
 [target.'cfg(not(windows))'.dependencies.fs-set-times]
 # cap-primitives permits fs-set-times 0.19.2, which moved to rustix 0.38

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,31 +21,33 @@ appveyor = { repository = "BurntSushi/walkdir" }
 members = ["walkdir-list"]
 
 [dependencies]
-cap-std = { version = "1.0.15", default-features = false }
 same-file = "1.0.1"
 
-[target.'cfg(not(windows))'.dependencies.rustix]
+[target.'cfg(unix)'.dependencies]
+cap-std = { version = "1.0.15", default-features = false }
+
+[target.'cfg(unix)'.dependencies.rustix]
 # cap-std's dependency tree still permits old rustix 0.37 releases under
 # minimal-versions. Pin a current patch release for current nightly.
 version = "0.37.28"
 default-features = false
 features = ["use-libc"]
 
-[target.'cfg(not(windows))'.dependencies.fs-set-times]
+[target.'cfg(unix)'.dependencies.fs-set-times]
 # cap-primitives permits fs-set-times 0.19.2, which moved to rustix 0.38
 # and raises the effective MSRV above walkdir's Rust 1.60 floor.
 version = "=0.19.1"
 
-[target.'cfg(not(windows))'.dependencies.itoa]
+[target.'cfg(unix)'.dependencies.itoa]
 # rustix 0.37 permits newer itoa patch releases whose MSRV is above Rust 1.60.
 version = "=1.0.15"
 
-[target.'cfg(not(windows))'.dependencies.libc]
+[target.'cfg(unix)'.dependencies.libc]
 # rustix and io-lifetimes permit newer libc patch releases whose MSRV is
 # above Rust 1.60.
 version = "=0.2.155"
 
-[target.'cfg(not(windows))'.dependencies.once_cell]
+[target.'cfg(unix)'.dependencies.once_cell]
 # rustix 0.37 permits newer once_cell patch releases whose MSRV is above
 # Rust 1.60.
 version = "=1.20.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,9 @@ version = "=0.2.155"
 version = "=1.20.3"
 
 [target.'cfg(windows)'.dependencies.winapi-util]
-version = "0.1.1"
+# Newer winapi-util patch releases moved to windows-sys/windows-link with an
+# MSRV above Rust 1.60.
+version = "=0.1.5"
 
 [dev-dependencies]
 doc-comment = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,11 @@ version = "=1.0.15"
 # above Rust 1.60.
 version = "=0.2.155"
 
+[target.'cfg(not(windows))'.dependencies.once_cell]
+# rustix 0.37 permits newer once_cell patch releases whose MSRV is above
+# Rust 1.60.
+version = "=1.20.3"
+
 [target.'cfg(windows)'.dependencies.winapi-util]
 version = "0.1.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ appveyor = { repository = "BurntSushi/walkdir" }
 members = ["walkdir-list"]
 
 [dependencies]
+cap-std = { version = "4.0.2", default-features = false }
 same-file = "1.0.1"
 
 [target.'cfg(windows)'.dependencies.winapi-util]
@@ -28,3 +29,4 @@ version = "0.1.1"
 
 [dev-dependencies]
 doc-comment = "0.3"
+libc = "0.2.186"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,12 @@ members = ["walkdir-list"]
 cap-std = { version = "4.0.2", default-features = false }
 same-file = "1.0.1"
 
+[target.'cfg(not(windows))'.dependencies.rustix]
+# cap-std's dependency tree still permits old rustix 0.38 releases under
+# minimal-versions. rustix 0.38.0 does not build on current nightly.
+version = "0.38.44"
+default-features = false
+
 [target.'cfg(windows)'.dependencies.winapi-util]
 version = "0.1.1"
 

--- a/src/dent.rs
+++ b/src/dent.rs
@@ -1,7 +1,11 @@
 use std::ffi::OsStr;
 use std::fmt;
 use std::fs::{self, FileType};
+use std::io;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use cap_std::fs as capfs;
 
 use crate::error::Error;
 use crate::Result;
@@ -43,19 +47,20 @@ pub struct DirEntry {
     /// Is set when this entry was created from a symbolic link and the user
     /// expects the iterator to follow symbolic links.
     follow_link: bool,
+    /// Is set when descriptor-relative traversal can identify an entry as a
+    /// symbolic link but the ambient path is too long to construct a
+    /// `std::fs::FileType` for it.
+    cap_symlink: bool,
     /// The depth at which this entry was generated relative to the root.
     depth: usize,
     /// The underlying inode number (Unix only).
     #[cfg(unix)]
     ino: u64,
-    /// The underlying metadata (Windows only). We store this on Windows
-    /// because this comes for free while reading a directory.
-    ///
-    /// We use this to determine whether an entry is a directory or not, which
-    /// works around a bug in Rust's standard library:
-    /// https://github.com/rust-lang/rust/issues/46484
-    #[cfg(windows)]
-    metadata: fs::Metadata,
+    /// The underlying metadata when it was already needed to create the entry.
+    metadata: Option<fs::Metadata>,
+    /// The path to this entry relative to the traversal root, when it was
+    /// found through descriptor-relative traversal.
+    cap_rel_path: Option<PathBuf>,
 }
 
 impl DirEntry {
@@ -98,7 +103,7 @@ impl DirEntry {
     /// [`follow_links`]: struct.WalkDir.html#method.follow_links
     /// [`std::fs::read_link(entry.path())`]: https://doc.rust-lang.org/stable/std/fs/fn.read_link.html
     pub fn path_is_symlink(&self) -> bool {
-        self.ty.is_symlink() || self.follow_link
+        self.is_symlink() || self.follow_link
     }
 
     /// Return the metadata for the file that this entry points to.
@@ -127,18 +132,15 @@ impl DirEntry {
         self.metadata_internal()
     }
 
-    #[cfg(windows)]
-    fn metadata_internal(&self) -> Result<fs::Metadata> {
-        if self.follow_link {
-            fs::metadata(&self.path)
-        } else {
-            Ok(self.metadata.clone())
+    pub(crate) fn metadata_internal(&self) -> Result<fs::Metadata> {
+        if let Some(metadata) = &self.metadata {
+            return Ok(metadata.clone());
         }
-        .map_err(|err| Error::from_entry(self, err))
-    }
+        if self.cap_symlink && !self.follow_link {
+            return cap_symlink_metadata_placeholder()
+                .map_err(|err| Error::from_entry(self, err));
+        }
 
-    #[cfg(not(windows))]
-    fn metadata_internal(&self) -> Result<fs::Metadata> {
         if self.follow_link {
             fs::metadata(&self.path)
         } else {
@@ -181,6 +183,78 @@ impl DirEntry {
         self.ty.is_dir()
     }
 
+    pub(crate) fn is_symlink(&self) -> bool {
+        self.ty.is_symlink() || self.cap_symlink
+    }
+
+    pub(crate) fn cap_rel_path(&self) -> Option<&Path> {
+        self.cap_rel_path.as_deref()
+    }
+
+    pub(crate) fn set_cap_rel_path(&mut self, rel_path: PathBuf) {
+        self.cap_rel_path = Some(rel_path);
+    }
+
+    #[cfg(windows)]
+    pub(crate) fn from_path_metadata(
+        depth: usize,
+        path: PathBuf,
+        follow_link: bool,
+        metadata: fs::Metadata,
+        cap_rel_path: Option<PathBuf>,
+    ) -> DirEntry {
+        DirEntry {
+            path,
+            ty: metadata.file_type(),
+            follow_link,
+            cap_symlink: false,
+            depth,
+            metadata: Some(metadata),
+            cap_rel_path,
+        }
+    }
+
+    #[cfg(unix)]
+    pub(crate) fn from_path_metadata(
+        depth: usize,
+        path: PathBuf,
+        follow_link: bool,
+        metadata: fs::Metadata,
+        cap_rel_path: Option<PathBuf>,
+    ) -> DirEntry {
+        use std::os::unix::fs::MetadataExt;
+
+        DirEntry {
+            path,
+            ty: metadata.file_type(),
+            follow_link,
+            cap_symlink: false,
+            depth,
+            ino: metadata.ino(),
+            metadata: Some(metadata),
+            cap_rel_path,
+        }
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    pub(crate) fn from_path_metadata(
+        depth: usize,
+        path: PathBuf,
+        follow_link: bool,
+        metadata: fs::Metadata,
+        cap_rel_path: Option<PathBuf>,
+    ) -> DirEntry {
+        DirEntry {
+            path,
+            ty: metadata.file_type(),
+            follow_link,
+            cap_symlink: false,
+            depth,
+            metadata: Some(metadata),
+            cap_rel_path,
+        }
+    }
+
     #[cfg(windows)]
     pub(crate) fn from_entry(
         depth: usize,
@@ -193,7 +267,15 @@ impl DirEntry {
         let md = ent
             .metadata()
             .map_err(|err| Error::from_path(depth, path.clone(), err))?;
-        Ok(DirEntry { path, ty, follow_link: false, depth, metadata: md })
+        Ok(DirEntry {
+            path,
+            ty,
+            follow_link: false,
+            cap_symlink: false,
+            depth,
+            metadata: Some(md),
+            cap_rel_path: None,
+        })
     }
 
     #[cfg(unix)]
@@ -210,8 +292,11 @@ impl DirEntry {
             path: ent.path(),
             ty,
             follow_link: false,
+            cap_symlink: false,
             depth,
             ino: ent.ino(),
+            metadata: None,
+            cap_rel_path: None,
         })
     }
 
@@ -223,7 +308,15 @@ impl DirEntry {
         let ty = ent
             .file_type()
             .map_err(|err| Error::from_path(depth, ent.path(), err))?;
-        Ok(DirEntry { path: ent.path(), ty, follow_link: false, depth })
+        Ok(DirEntry {
+            path: ent.path(),
+            ty,
+            follow_link: false,
+            cap_symlink: false,
+            depth,
+            metadata: None,
+            cap_rel_path: None,
+        })
     }
 
     #[cfg(windows)]
@@ -243,8 +336,10 @@ impl DirEntry {
             path: pb,
             ty: md.file_type(),
             follow_link: follow,
+            cap_symlink: false,
             depth,
-            metadata: md,
+            metadata: Some(md),
+            cap_rel_path: None,
         })
     }
 
@@ -263,12 +358,16 @@ impl DirEntry {
             fs::symlink_metadata(&pb)
                 .map_err(|err| Error::from_path(depth, pb.clone(), err))?
         };
+        let ty = md.file_type();
         Ok(DirEntry {
             path: pb,
-            ty: md.file_type(),
+            ty,
             follow_link: follow,
+            cap_symlink: false,
             depth,
             ino: md.ino(),
+            metadata: None,
+            cap_rel_path: None,
         })
     }
 
@@ -285,13 +384,193 @@ impl DirEntry {
             fs::symlink_metadata(&pb)
                 .map_err(|err| Error::from_path(depth, pb.clone(), err))?
         };
+        let ty = md.file_type();
         Ok(DirEntry {
             path: pb,
-            ty: md.file_type(),
+            ty,
             follow_link: follow,
+            cap_symlink: false,
             depth,
+            metadata: Some(md),
+            cap_rel_path: None,
         })
     }
+
+    pub(crate) fn from_cap_entry(
+        depth: usize,
+        parent: &Path,
+        parent_rel_path: &Path,
+        ent: capfs::DirEntry,
+        follow_links: bool,
+    ) -> Result<DirEntry> {
+        let file_name = ent.file_name();
+        let path = parent.join(&file_name);
+        let rel_path = parent_rel_path.join(&file_name);
+        let cap_ty = ent
+            .file_type()
+            .map_err(|err| Error::from_path(depth, path.clone(), err))?;
+        let (ty, metadata) = std_file_type_and_metadata(
+            depth,
+            &path,
+            &ent,
+            cap_ty,
+            follow_links,
+        )?;
+
+        #[cfg(unix)]
+        {
+            use cap_std::fs::MetadataExt as CapMetadataExt;
+            use std::os::unix::fs::MetadataExt as StdMetadataExt;
+
+            let ino = metadata.as_ref().map_or_else(
+                || {
+                    ent.metadata().map(|md| CapMetadataExt::ino(&md)).map_err(
+                        |err| Error::from_path(depth, path.clone(), err),
+                    )
+                },
+                |md| Ok(StdMetadataExt::ino(md)),
+            )?;
+            return Ok(DirEntry {
+                path,
+                ty,
+                follow_link: false,
+                cap_symlink: cap_ty.is_symlink(),
+                depth,
+                ino,
+                metadata,
+                cap_rel_path: Some(rel_path),
+            });
+        }
+
+        #[cfg(windows)]
+        {
+            return Ok(DirEntry {
+                path,
+                ty,
+                follow_link: false,
+                cap_symlink: cap_ty.is_symlink(),
+                depth,
+                metadata,
+                cap_rel_path: Some(rel_path),
+            });
+        }
+
+        #[cfg(not(any(unix, windows)))]
+        {
+            Ok(DirEntry {
+                path,
+                ty,
+                follow_link: false,
+                cap_symlink: cap_ty.is_symlink(),
+                depth,
+                metadata,
+                cap_rel_path: Some(rel_path),
+            })
+        }
+    }
+}
+
+fn std_file_type_and_metadata(
+    depth: usize,
+    path: &Path,
+    ent: &capfs::DirEntry,
+    cap_ty: capfs::FileType,
+    _follow_links: bool,
+) -> Result<(FileType, Option<fs::Metadata>)> {
+    if let Ok(md) = fs::symlink_metadata(path) {
+        let ty = md.file_type();
+        return Ok((ty, None));
+    }
+
+    if cap_ty.is_dir() {
+        let dir = ent
+            .open_dir()
+            .map_err(|err| Error::from_path(depth, path.to_path_buf(), err))?;
+        let std_file = dir.into_std_file();
+        let md = std_file
+            .metadata()
+            .map_err(|err| Error::from_path(depth, path.to_path_buf(), err))?;
+        let ty = md.file_type();
+        return Ok((ty, Some(md)));
+    }
+
+    if cap_ty.is_file() {
+        let file = ent
+            .open()
+            .map_err(|err| Error::from_path(depth, path.to_path_buf(), err))?;
+        let md = file
+            .into_std()
+            .metadata()
+            .map_err(|err| Error::from_path(depth, path.to_path_buf(), err))?;
+        let ty = md.file_type();
+        return Ok((ty, Some(md)));
+    }
+
+    if cap_ty.is_symlink() {
+        let ty = cap_symlink_placeholder()
+            .map_err(|err| Error::from_path(depth, path.to_path_buf(), err))?;
+        return Ok((ty, None));
+    }
+
+    fs::symlink_metadata(path)
+        .map(|md| (md.file_type(), Some(md)))
+        .map_err(|err| Error::from_path(depth, path.to_path_buf(), err))
+}
+
+fn cap_symlink_placeholder() -> io::Result<FileType> {
+    cap_symlink_metadata_placeholder().map(|md| md.file_type())
+}
+
+fn cap_symlink_metadata_placeholder() -> io::Result<fs::Metadata> {
+    static METADATA: OnceLock<Option<fs::Metadata>> = OnceLock::new();
+    METADATA
+        .get_or_init(|| make_symlink_metadata_placeholder().ok())
+        .clone()
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::Other,
+                "walkdir: could not create symlink metadata placeholder",
+            )
+        })
+}
+
+fn make_symlink_metadata_placeholder() -> io::Result<fs::Metadata> {
+    let root = std::env::temp_dir()
+        .join(format!("walkdir-symlink-metadata-{}", std::process::id()));
+    let link = root.join("link");
+    let _ = fs::remove_dir_all(&root);
+    fs::create_dir(&root)?;
+    create_symlink("target", &link)?;
+    let metadata = fs::symlink_metadata(&link);
+    let _ = fs::remove_dir_all(&root);
+    metadata
+}
+
+#[cfg(unix)]
+fn create_symlink<P: AsRef<Path>, Q: AsRef<Path>>(
+    target: P,
+    link: Q,
+) -> io::Result<()> {
+    std::os::unix::fs::symlink(target, link)
+}
+
+#[cfg(windows)]
+fn create_symlink<P: AsRef<Path>, Q: AsRef<Path>>(
+    target: P,
+    link: Q,
+) -> io::Result<()> {
+    std::os::windows::fs::symlink_file(target, link)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn create_symlink<P: AsRef<Path>, Q: AsRef<Path>>(
+    _target: P,
+    _link: Q,
+) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Other,
+        "walkdir: symlink metadata placeholder unsupported on this platform",
+    ))
 }
 
 impl Clone for DirEntry {
@@ -301,8 +580,10 @@ impl Clone for DirEntry {
             path: self.path.clone(),
             ty: self.ty,
             follow_link: self.follow_link,
+            cap_symlink: self.cap_symlink,
             depth: self.depth,
             metadata: self.metadata.clone(),
+            cap_rel_path: self.cap_rel_path.clone(),
         }
     }
 
@@ -312,8 +593,11 @@ impl Clone for DirEntry {
             path: self.path.clone(),
             ty: self.ty,
             follow_link: self.follow_link,
+            cap_symlink: self.cap_symlink,
             depth: self.depth,
             ino: self.ino,
+            metadata: self.metadata.clone(),
+            cap_rel_path: self.cap_rel_path.clone(),
         }
     }
 
@@ -323,7 +607,10 @@ impl Clone for DirEntry {
             path: self.path.clone(),
             ty: self.ty,
             follow_link: self.follow_link,
+            cap_symlink: self.cap_symlink,
             depth: self.depth,
+            metadata: self.metadata.clone(),
+            cap_rel_path: self.cap_rel_path.clone(),
         }
     }
 }

--- a/src/dent.rs
+++ b/src/dent.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::fs::{self, FileType};
 use std::io;
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use cap_std::fs as capfs;
 
@@ -419,15 +419,11 @@ impl DirEntry {
 
         #[cfg(unix)]
         {
-            use cap_std::fs::MetadataExt as CapMetadataExt;
+            use rustix::fs::DirEntryExt as CapDirEntryExt;
             use std::os::unix::fs::MetadataExt as StdMetadataExt;
 
             let ino = metadata.as_ref().map_or_else(
-                || {
-                    ent.metadata().map(|md| CapMetadataExt::ino(&md)).map_err(
-                        |err| Error::from_path(depth, path.clone(), err),
-                    )
-                },
+                || Ok(CapDirEntryExt::ino(&ent)),
                 |md| Ok(StdMetadataExt::ino(md)),
             )?;
             return Ok(DirEntry {
@@ -479,7 +475,7 @@ fn std_file_type_and_metadata(
 ) -> Result<(FileType, Option<fs::Metadata>)> {
     if let Ok(md) = fs::symlink_metadata(path) {
         let ty = md.file_type();
-        return Ok((ty, None));
+        return Ok((ty, Some(md)));
     }
 
     if cap_ty.is_dir() {
@@ -522,21 +518,22 @@ fn cap_symlink_placeholder() -> io::Result<FileType> {
 }
 
 fn cap_symlink_metadata_placeholder() -> io::Result<fs::Metadata> {
-    static METADATA: OnceLock<Option<fs::Metadata>> = OnceLock::new();
-    METADATA
-        .get_or_init(|| make_symlink_metadata_placeholder().ok())
-        .clone()
-        .ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::Other,
-                "walkdir: could not create symlink metadata placeholder",
-            )
-        })
+    make_symlink_metadata_placeholder().map_err(|_| {
+        io::Error::new(
+            io::ErrorKind::Other,
+            "walkdir: could not create symlink metadata placeholder",
+        )
+    })
 }
 
 fn make_symlink_metadata_placeholder() -> io::Result<fs::Metadata> {
-    let root = std::env::temp_dir()
-        .join(format!("walkdir-symlink-metadata-{}", std::process::id()));
+    static NEXT: AtomicUsize = AtomicUsize::new(0);
+
+    let root = std::env::temp_dir().join(format!(
+        "walkdir-symlink-metadata-{}-{}",
+        std::process::id(),
+        NEXT.fetch_add(1, Ordering::Relaxed)
+    ));
     let link = root.join("link");
     let _ = fs::remove_dir_all(&root);
     fs::create_dir(&root)?;

--- a/src/dent.rs
+++ b/src/dent.rs
@@ -1,10 +1,13 @@
 use std::ffi::OsStr;
 use std::fmt;
 use std::fs::{self, FileType};
+#[cfg(unix)]
 use std::io;
 use std::path::{Path, PathBuf};
+#[cfg(unix)]
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+#[cfg(unix)]
 use cap_std::fs as capfs;
 
 use crate::error::Error;
@@ -136,9 +139,12 @@ impl DirEntry {
         if let Some(metadata) = &self.metadata {
             return Ok(metadata.clone());
         }
-        if self.cap_symlink && !self.follow_link {
-            return cap_symlink_metadata_placeholder()
-                .map_err(|err| Error::from_entry(self, err));
+        #[cfg(unix)]
+        {
+            if self.cap_symlink && !self.follow_link {
+                return cap_symlink_metadata_placeholder()
+                    .map_err(|err| Error::from_entry(self, err));
+            }
         }
 
         if self.follow_link {
@@ -187,31 +193,14 @@ impl DirEntry {
         self.ty.is_symlink() || self.cap_symlink
     }
 
+    #[cfg(unix)]
     pub(crate) fn cap_rel_path(&self) -> Option<&Path> {
         self.cap_rel_path.as_deref()
     }
 
+    #[cfg(unix)]
     pub(crate) fn set_cap_rel_path(&mut self, rel_path: PathBuf) {
         self.cap_rel_path = Some(rel_path);
-    }
-
-    #[cfg(windows)]
-    pub(crate) fn from_path_metadata(
-        depth: usize,
-        path: PathBuf,
-        follow_link: bool,
-        metadata: fs::Metadata,
-        cap_rel_path: Option<PathBuf>,
-    ) -> DirEntry {
-        DirEntry {
-            path,
-            ty: metadata.file_type(),
-            follow_link,
-            cap_symlink: false,
-            depth,
-            metadata: Some(metadata),
-            cap_rel_path,
-        }
     }
 
     #[cfg(unix)]
@@ -231,25 +220,6 @@ impl DirEntry {
             cap_symlink: false,
             depth,
             ino: metadata.ino(),
-            metadata: Some(metadata),
-            cap_rel_path,
-        }
-    }
-
-    #[cfg(not(any(unix, windows)))]
-    pub(crate) fn from_path_metadata(
-        depth: usize,
-        path: PathBuf,
-        follow_link: bool,
-        metadata: fs::Metadata,
-        cap_rel_path: Option<PathBuf>,
-    ) -> DirEntry {
-        DirEntry {
-            path,
-            ty: metadata.file_type(),
-            follow_link,
-            cap_symlink: false,
-            depth,
             metadata: Some(metadata),
             cap_rel_path,
         }
@@ -396,6 +366,7 @@ impl DirEntry {
         })
     }
 
+    #[cfg(unix)]
     pub(crate) fn from_cap_entry(
         depth: usize,
         parent: &Path,
@@ -466,6 +437,7 @@ impl DirEntry {
     }
 }
 
+#[cfg(unix)]
 fn std_file_type_and_metadata(
     depth: usize,
     path: &Path,
@@ -513,10 +485,12 @@ fn std_file_type_and_metadata(
         .map_err(|err| Error::from_path(depth, path.to_path_buf(), err))
 }
 
+#[cfg(unix)]
 fn cap_symlink_placeholder() -> io::Result<FileType> {
     cap_symlink_metadata_placeholder().map(|md| md.file_type())
 }
 
+#[cfg(unix)]
 fn cap_symlink_metadata_placeholder() -> io::Result<fs::Metadata> {
     make_symlink_metadata_placeholder().map_err(|_| {
         io::Error::new(
@@ -526,6 +500,7 @@ fn cap_symlink_metadata_placeholder() -> io::Result<fs::Metadata> {
     })
 }
 
+#[cfg(unix)]
 fn make_symlink_metadata_placeholder() -> io::Result<fs::Metadata> {
     static NEXT: AtomicUsize = AtomicUsize::new(0);
 
@@ -549,25 +524,6 @@ fn create_symlink<P: AsRef<Path>, Q: AsRef<Path>>(
     link: Q,
 ) -> io::Result<()> {
     std::os::unix::fs::symlink(target, link)
-}
-
-#[cfg(windows)]
-fn create_symlink<P: AsRef<Path>, Q: AsRef<Path>>(
-    target: P,
-    link: Q,
-) -> io::Result<()> {
-    std::os::windows::fs::symlink_file(target, link)
-}
-
-#[cfg(not(any(unix, windows)))]
-fn create_symlink<P: AsRef<Path>, Q: AsRef<Path>>(
-    _target: P,
-    _link: Q,
-) -> io::Result<()> {
-    Err(io::Error::new(
-        io::ErrorKind::Other,
-        "walkdir: symlink metadata placeholder unsupported on this platform",
-    ))
 }
 
 impl Clone for DirEntry {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,9 @@ use std::path::{Path, PathBuf};
 use std::result;
 use std::vec;
 
+#[cfg(unix)]
 use cap_std::ambient_authority;
+#[cfg(unix)]
 use cap_std::fs as capfs;
 #[cfg(not(unix))]
 use same_file::Handle;
@@ -550,6 +552,7 @@ impl IntoIterator for WalkDir {
             depth: 0,
             deferred_dirs: vec![],
             root_device: None,
+            #[cfg(unix)]
             cap_root: None,
         }
     }
@@ -609,6 +612,7 @@ pub struct IntoIter {
     root_device: Option<u64>,
     /// The root directory used to reopen descriptor-relative entries without
     /// storing open handles on yielded entries.
+    #[cfg(unix)]
     cap_root: Option<PathBuf>,
 }
 
@@ -703,6 +707,7 @@ enum DirList {
     /// [`Option<...>`]: https://doc.rust-lang.org/stable/std/option/enum.Option.html
     Opened { depth: usize, it: result::Result<ReadDir, Option<Error>> },
     /// An opened descriptor-relative handle.
+    #[cfg(unix)]
     CapOpened {
         depth: usize,
         parent_path: PathBuf,
@@ -731,15 +736,20 @@ impl Iterator for IntoIter {
                     .map_err(|e| Error::from_path(0, start.clone(), e));
                 self.root_device = Some(itry!(result));
             }
-            let mut dent = itry!(DirEntry::from_path(0, start, false));
+            let dent = itry!(DirEntry::from_path(0, start, false));
+            #[cfg(unix)]
+            let mut dent = dent;
             if dent.is_dir() {
-                if let Ok(dir) = capfs::Dir::open_ambient_dir(
-                    dent.path(),
-                    ambient_authority(),
-                ) {
-                    drop(dir);
-                    self.cap_root = Some(dent.path().to_path_buf());
-                    dent.set_cap_rel_path(PathBuf::new());
+                #[cfg(unix)]
+                {
+                    if let Ok(dir) = capfs::Dir::open_ambient_dir(
+                        dent.path(),
+                        ambient_authority(),
+                    ) {
+                        drop(dir);
+                        self.cap_root = Some(dent.path().to_path_buf());
+                        dent.set_cap_rel_path(PathBuf::new());
+                    }
                 }
             }
             if let Some(result) = self.handle_entry(dent) {
@@ -956,41 +966,57 @@ impl IntoIter {
             self.stack_list[self.oldest_opened].close();
         }
         // Open a handle to reading the directory's entries.
-        let mut list = if let (Some(root), Some(rel_path)) =
-            (self.cap_root.as_deref(), dent.cap_rel_path())
-        {
-            let dir = open_cap_dir(root, rel_path).map_err(|err| {
-                Some(Error::from_path(
-                    self.depth,
-                    dent.path().to_path_buf(),
-                    err,
-                ))
-            });
-            let rd = dir.and_then(|dir| {
-                dir.entries().map_err(|err| {
+        let mut list = {
+            #[cfg(unix)]
+            {
+                if let (Some(root), Some(rel_path)) =
+                    (self.cap_root.as_deref(), dent.cap_rel_path())
+                {
+                    let dir = open_cap_dir(root, rel_path).map_err(|err| {
+                        Some(Error::from_path(
+                            self.depth,
+                            dent.path().to_path_buf(),
+                            err,
+                        ))
+                    });
+                    let rd = dir.and_then(|dir| {
+                        dir.entries().map_err(|err| {
+                            Some(Error::from_path(
+                                self.depth,
+                                dent.path().to_path_buf(),
+                                err,
+                            ))
+                        })
+                    });
+                    DirList::CapOpened {
+                        depth: self.depth,
+                        parent_path: dent.path().to_path_buf(),
+                        parent_rel_path: rel_path.to_path_buf(),
+                        follow_links: self.opts.follow_links,
+                        it: rd,
+                    }
+                } else {
+                    let rd = fs::read_dir(dent.path()).map_err(|err| {
+                        Some(Error::from_path(
+                            self.depth,
+                            dent.path().to_path_buf(),
+                            err,
+                        ))
+                    });
+                    DirList::Opened { depth: self.depth, it: rd }
+                }
+            }
+            #[cfg(not(unix))]
+            {
+                let rd = fs::read_dir(dent.path()).map_err(|err| {
                     Some(Error::from_path(
                         self.depth,
                         dent.path().to_path_buf(),
                         err,
                     ))
-                })
-            });
-            DirList::CapOpened {
-                depth: self.depth,
-                parent_path: dent.path().to_path_buf(),
-                parent_rel_path: rel_path.to_path_buf(),
-                follow_links: self.opts.follow_links,
-                it: rd,
+                });
+                DirList::Opened { depth: self.depth, it: rd }
             }
-        } else {
-            let rd = fs::read_dir(dent.path()).map_err(|err| {
-                Some(Error::from_path(
-                    self.depth,
-                    dent.path().to_path_buf(),
-                    err,
-                ))
-            });
-            DirList::Opened { depth: self.depth, it: rd }
         };
         if let Some(ref mut cmp) = self.opts.sorter {
             let mut entries: Vec<_> = list.collect();
@@ -1041,26 +1067,41 @@ impl IntoIter {
     }
 
     fn follow(&self, mut dent: DirEntry) -> Result<DirEntry> {
-        dent = if let (Some(root), Some(rel_path)) =
-            (self.cap_root.as_deref(), dent.cap_rel_path())
+        #[cfg(unix)]
         {
-            match cap_metadata(root, rel_path) {
-                Ok(metadata) => DirEntry::from_path_metadata(
+            dent = if let (Some(root), Some(rel_path)) =
+                (self.cap_root.as_deref(), dent.cap_rel_path())
+            {
+                match cap_metadata(root, rel_path) {
+                    Ok(metadata) => DirEntry::from_path_metadata(
+                        self.depth,
+                        dent.path().to_path_buf(),
+                        true,
+                        metadata,
+                        Some(rel_path.to_path_buf()),
+                    ),
+                    Err(_) => DirEntry::from_path(
+                        self.depth,
+                        dent.path().to_path_buf(),
+                        true,
+                    )?,
+                }
+            } else {
+                DirEntry::from_path(
                     self.depth,
                     dent.path().to_path_buf(),
                     true,
-                    metadata,
-                    Some(rel_path.to_path_buf()),
-                ),
-                Err(_) => DirEntry::from_path(
-                    self.depth,
-                    dent.path().to_path_buf(),
-                    true,
-                )?,
+                )?
             }
-        } else {
-            DirEntry::from_path(self.depth, dent.path().to_path_buf(), true)?
-        };
+        }
+        #[cfg(not(unix))]
+        {
+            dent = DirEntry::from_path(
+                self.depth,
+                dent.path().to_path_buf(),
+                true,
+            )?;
+        }
         // The only way a symlink can cause a loop is if it points
         // to a directory. Otherwise, it always points to a leaf
         // and we can omit any loop checks.
@@ -1132,8 +1173,13 @@ impl iter::FusedIterator for IntoIter {}
 
 impl DirList {
     fn close(&mut self) {
-        if matches!(*self, DirList::Opened { .. } | DirList::CapOpened { .. })
-        {
+        let is_open = match *self {
+            DirList::Opened { .. } => true,
+            #[cfg(unix)]
+            DirList::CapOpened { .. } => true,
+            DirList::Closed(_) => false,
+        };
+        if is_open {
             *self = DirList::Closed(self.collect::<Vec<_>>().into_iter());
         }
     }
@@ -1153,6 +1199,7 @@ impl Iterator for DirList {
                     Err(err) => Err(Error::from_io(depth + 1, err)),
                 }),
             },
+            #[cfg(unix)]
             DirList::CapOpened {
                 depth,
                 ref parent_path,
@@ -1176,6 +1223,7 @@ impl Iterator for DirList {
     }
 }
 
+#[cfg(unix)]
 fn open_cap_dir(root: &Path, rel_path: &Path) -> io::Result<capfs::Dir> {
     let mut dir = capfs::Dir::open_ambient_dir(root, ambient_authority())?;
     for component in rel_path.components() {
@@ -1197,6 +1245,7 @@ fn open_cap_dir(root: &Path, rel_path: &Path) -> io::Result<capfs::Dir> {
     Ok(dir)
 }
 
+#[cfg(unix)]
 fn cap_metadata(root: &Path, rel_path: &Path) -> io::Result<fs::Metadata> {
     match open_cap_dir(root, rel_path) {
         Ok(dir) => return dir.into_std_file().metadata(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1107,9 +1107,16 @@ impl IntoIter {
     }
 
     fn is_same_file_system(&mut self, dent: &DirEntry) -> Result<bool> {
-        let md = dent.metadata_internal()?;
-        let dent_device = util::device_num_from_metadata(&md)
+        #[cfg(windows)]
+        let dent_device = util::device_num(dent.path())
             .map_err(|err| Error::from_entry(dent, err))?;
+
+        #[cfg(not(windows))]
+        let dent_device = {
+            let md = dent.metadata_internal()?;
+            util::device_num_from_metadata(&md)
+                .map_err(|err| Error::from_entry(dent, err))?
+        };
         Ok(self
             .root_device
             .map(|d| d == dent_device)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,9 @@ use std::path::{Path, PathBuf};
 use std::result;
 use std::vec;
 
+use cap_std::ambient_authority;
+use cap_std::fs as capfs;
+#[cfg(not(unix))]
 use same_file::Handle;
 
 pub use crate::dent::DirEntry;
@@ -547,6 +550,7 @@ impl IntoIterator for WalkDir {
             depth: 0,
             deferred_dirs: vec![],
             root_device: None,
+            cap_root: None,
         }
     }
 }
@@ -603,6 +607,9 @@ pub struct IntoIter {
     /// `None`. Conversely, if it is enabled, this is always `Some(...)` after
     /// handling the root path.
     root_device: Option<u64>,
+    /// The root directory used to reopen descriptor-relative entries without
+    /// storing open handles on yielded entries.
+    cap_root: Option<PathBuf>,
 }
 
 /// An ancestor is an item in the directory tree traversed by walkdir, and is
@@ -611,6 +618,9 @@ pub struct IntoIter {
 struct Ancestor {
     /// The path of this ancestor.
     path: PathBuf,
+    /// The device and inode for this ancestor.
+    #[cfg(unix)]
+    metadata: (u64, u64),
     /// An open file to this ancesor. This is only used on Windows where
     /// opening a file handle appears to be quite expensive, so we choose to
     /// cache it. This comes at the cost of not respecting the file descriptor
@@ -628,7 +638,19 @@ impl Ancestor {
     }
 
     /// Create a new ancestor from the given directory path.
-    #[cfg(not(windows))]
+    #[cfg(unix)]
+    fn new(dent: &DirEntry) -> io::Result<Ancestor> {
+        use std::os::unix::fs::MetadataExt;
+
+        let md = dent.metadata_internal().map_err(io::Error::from)?;
+        Ok(Ancestor {
+            path: dent.path().to_path_buf(),
+            metadata: (md.dev(), md.ino()),
+        })
+    }
+
+    /// Create a new ancestor from the given directory path.
+    #[cfg(not(any(unix, windows)))]
     fn new(dent: &DirEntry) -> io::Result<Ancestor> {
         Ok(Ancestor { path: dent.path().to_path_buf() })
     }
@@ -642,7 +664,17 @@ impl Ancestor {
 
     /// Returns true if and only if the given open file handle corresponds to
     /// the same directory as this ancestor.
-    #[cfg(not(windows))]
+    #[cfg(unix)]
+    fn is_same(&self, child: &DirEntry) -> io::Result<bool> {
+        use std::os::unix::fs::MetadataExt;
+
+        let md = child.metadata_internal().map_err(io::Error::from)?;
+        Ok(self.metadata == (md.dev(), md.ino()))
+    }
+
+    /// Returns true if and only if the given open file handle corresponds to
+    /// the same directory as this ancestor.
+    #[cfg(not(any(unix, windows)))]
     fn is_same(&self, child: &Handle) -> io::Result<bool> {
         Ok(child == &Handle::from_path(&self.path)?)
     }
@@ -670,6 +702,14 @@ enum DirList {
     /// [`fs::read_dir`]: https://doc.rust-lang.org/stable/std/fs/fn.read_dir.html
     /// [`Option<...>`]: https://doc.rust-lang.org/stable/std/option/enum.Option.html
     Opened { depth: usize, it: result::Result<ReadDir, Option<Error>> },
+    /// An opened descriptor-relative handle.
+    CapOpened {
+        depth: usize,
+        parent_path: PathBuf,
+        parent_rel_path: PathBuf,
+        follow_links: bool,
+        it: result::Result<capfs::ReadDir, Option<Error>>,
+    },
     /// A closed handle.
     ///
     /// All remaining directory entries are read into memory.
@@ -691,7 +731,17 @@ impl Iterator for IntoIter {
                     .map_err(|e| Error::from_path(0, start.clone(), e));
                 self.root_device = Some(itry!(result));
             }
-            let dent = itry!(DirEntry::from_path(0, start, false));
+            let mut dent = itry!(DirEntry::from_path(0, start, false));
+            if dent.is_dir() {
+                if let Ok(dir) = capfs::Dir::open_ambient_dir(
+                    dent.path(),
+                    ambient_authority(),
+                ) {
+                    drop(dir);
+                    self.cap_root = Some(dent.path().to_path_buf());
+                    dent.set_cap_rel_path(PathBuf::new());
+                }
+            }
             if let Some(result) = self.handle_entry(dent) {
                 return Some(result);
             }
@@ -841,10 +891,10 @@ impl IntoIter {
         &mut self,
         mut dent: DirEntry,
     ) -> Option<Result<DirEntry>> {
-        if self.opts.follow_links && dent.file_type().is_symlink() {
+        if self.opts.follow_links && dent.is_symlink() {
             dent = itry!(self.follow(dent));
         }
-        let is_normal_dir = !dent.file_type().is_symlink() && dent.is_dir();
+        let is_normal_dir = !dent.is_symlink() && dent.is_dir();
         if is_normal_dir {
             if self.opts.same_file_system && dent.depth() > 0 {
                 if itry!(self.is_same_file_system(&dent)) {
@@ -854,7 +904,7 @@ impl IntoIter {
                 itry!(self.push(&dent));
             }
         } else if dent.depth() == 0
-            && dent.file_type().is_symlink()
+            && dent.is_symlink()
             && self.opts.follow_root_links
         {
             // As a special case, if we are processing a root entry, then we
@@ -906,10 +956,42 @@ impl IntoIter {
             self.stack_list[self.oldest_opened].close();
         }
         // Open a handle to reading the directory's entries.
-        let rd = fs::read_dir(dent.path()).map_err(|err| {
-            Some(Error::from_path(self.depth, dent.path().to_path_buf(), err))
-        });
-        let mut list = DirList::Opened { depth: self.depth, it: rd };
+        let mut list = if let (Some(root), Some(rel_path)) =
+            (self.cap_root.as_deref(), dent.cap_rel_path())
+        {
+            let dir = open_cap_dir(root, rel_path).map_err(|err| {
+                Some(Error::from_path(
+                    self.depth,
+                    dent.path().to_path_buf(),
+                    err,
+                ))
+            });
+            let rd = dir.and_then(|dir| {
+                dir.entries().map_err(|err| {
+                    Some(Error::from_path(
+                        self.depth,
+                        dent.path().to_path_buf(),
+                        err,
+                    ))
+                })
+            });
+            DirList::CapOpened {
+                depth: self.depth,
+                parent_path: dent.path().to_path_buf(),
+                parent_rel_path: rel_path.to_path_buf(),
+                follow_links: self.opts.follow_links,
+                it: rd,
+            }
+        } else {
+            let rd = fs::read_dir(dent.path()).map_err(|err| {
+                Some(Error::from_path(
+                    self.depth,
+                    dent.path().to_path_buf(),
+                    err,
+                ))
+            });
+            DirList::Opened { depth: self.depth, it: rd }
+        };
         if let Some(ref mut cmp) = self.opts.sorter {
             let mut entries: Vec<_> = list.collect();
             entries.sort_by(|a, b| match (a, b) {
@@ -959,19 +1041,38 @@ impl IntoIter {
     }
 
     fn follow(&self, mut dent: DirEntry) -> Result<DirEntry> {
-        dent =
-            DirEntry::from_path(self.depth, dent.path().to_path_buf(), true)?;
+        dent = if let (Some(root), Some(rel_path)) =
+            (self.cap_root.as_deref(), dent.cap_rel_path())
+        {
+            match cap_metadata(root, rel_path) {
+                Ok(metadata) => DirEntry::from_path_metadata(
+                    self.depth,
+                    dent.path().to_path_buf(),
+                    true,
+                    metadata,
+                    Some(rel_path.to_path_buf()),
+                ),
+                Err(_) => DirEntry::from_path(
+                    self.depth,
+                    dent.path().to_path_buf(),
+                    true,
+                )?,
+            }
+        } else {
+            DirEntry::from_path(self.depth, dent.path().to_path_buf(), true)?
+        };
         // The only way a symlink can cause a loop is if it points
         // to a directory. Otherwise, it always points to a leaf
         // and we can omit any loop checks.
         if dent.is_dir() {
-            self.check_loop(dent.path())?;
+            self.check_loop(&dent)?;
         }
         Ok(dent)
     }
 
-    fn check_loop<P: AsRef<Path>>(&self, child: P) -> Result<()> {
-        let hchild = Handle::from_path(&child)
+    #[cfg(not(unix))]
+    fn check_loop(&self, child: &DirEntry) -> Result<()> {
+        let hchild = Handle::from_path(child.path())
             .map_err(|err| Error::from_io(self.depth, err))?;
         for ancestor in self.stack_path.iter().rev() {
             let is_same = ancestor
@@ -981,7 +1082,24 @@ impl IntoIter {
                 return Err(Error::from_loop(
                     self.depth,
                     &ancestor.path,
-                    child.as_ref(),
+                    child.path(),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    fn check_loop(&self, child: &DirEntry) -> Result<()> {
+        for ancestor in self.stack_path.iter().rev() {
+            let is_same = ancestor
+                .is_same(child)
+                .map_err(|err| Error::from_io(self.depth, err))?;
+            if is_same {
+                return Err(Error::from_loop(
+                    self.depth,
+                    &ancestor.path,
+                    child.path(),
                 ));
             }
         }
@@ -989,7 +1107,8 @@ impl IntoIter {
     }
 
     fn is_same_file_system(&mut self, dent: &DirEntry) -> Result<bool> {
-        let dent_device = util::device_num(dent.path())
+        let md = dent.metadata_internal()?;
+        let dent_device = util::device_num_from_metadata(&md)
             .map_err(|err| Error::from_entry(dent, err))?;
         Ok(self
             .root_device
@@ -1006,7 +1125,8 @@ impl iter::FusedIterator for IntoIter {}
 
 impl DirList {
     fn close(&mut self) {
-        if let DirList::Opened { .. } = *self {
+        if matches!(*self, DirList::Opened { .. } | DirList::CapOpened { .. })
+        {
             *self = DirList::Closed(self.collect::<Vec<_>>().into_iter());
         }
     }
@@ -1026,6 +1146,59 @@ impl Iterator for DirList {
                     Err(err) => Err(Error::from_io(depth + 1, err)),
                 }),
             },
+            DirList::CapOpened {
+                depth,
+                ref parent_path,
+                ref parent_rel_path,
+                follow_links,
+                ref mut it,
+            } => match *it {
+                Err(ref mut err) => err.take().map(Err),
+                Ok(ref mut rd) => rd.next().map(|r| match r {
+                    Ok(r) => DirEntry::from_cap_entry(
+                        depth + 1,
+                        parent_path,
+                        parent_rel_path,
+                        r,
+                        follow_links,
+                    ),
+                    Err(err) => Err(Error::from_io(depth + 1, err)),
+                }),
+            },
+        }
+    }
+}
+
+fn open_cap_dir(root: &Path, rel_path: &Path) -> io::Result<capfs::Dir> {
+    let mut dir = capfs::Dir::open_ambient_dir(root, ambient_authority())?;
+    for component in rel_path.components() {
+        use std::path::Component;
+
+        match component {
+            Component::CurDir => {}
+            Component::Normal(name) => {
+                dir = dir.open_dir(Path::new(name))?;
+            }
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "walkdir: descriptor-relative path escaped root",
+                ));
+            }
+        }
+    }
+    Ok(dir)
+}
+
+fn cap_metadata(root: &Path, rel_path: &Path) -> io::Result<fs::Metadata> {
+    match open_cap_dir(root, rel_path) {
+        Ok(dir) => return dir.into_std_file().metadata(),
+        Err(dir_err) => {
+            let parent_rel_path =
+                rel_path.parent().unwrap_or_else(|| Path::new(""));
+            let file_name = rel_path.file_name().ok_or(dir_err)?;
+            let parent = open_cap_dir(root, parent_rel_path)?;
+            parent.open(Path::new(file_name))?.into_std().metadata()
         }
     }
 }

--- a/src/tests/recursive.rs
+++ b/src/tests/recursive.rs
@@ -433,7 +433,6 @@ fn assert_walk_does_not_follow_long_link(
 
 #[cfg(unix)]
 mod long_path {
-    use std::ffi::CString;
     use std::fs;
     use std::io;
     use std::os::unix::ffi::OsStrExt;
@@ -446,6 +445,7 @@ mod long_path {
     pub const LINK_DIR: &str = "link-dir";
     pub const LINK_LEAF: &str = "link-needle.txt";
     const LINK_TARGET: &str = "link-target";
+    const ASSUMED_PATH_MAX: usize = 4096;
 
     static NEXT: AtomicUsize = AtomicUsize::new(0);
 
@@ -476,7 +476,7 @@ mod long_path {
 
             fs::create_dir_all(&root)?;
             let root_dir = Dir::open_ambient_dir(&root, ambient_authority())?;
-            let path_max = path_max(&root).unwrap_or(4096);
+            let path_max = ASSUMED_PATH_MAX;
 
             let _ = root_dir.remove_dir_all("tree");
             root_dir.create_dir("tree")?;
@@ -550,12 +550,6 @@ mod long_path {
 
     fn root_dir_path(root: &Path) -> PathBuf {
         root.join("tree")
-    }
-
-    fn path_max(path: &Path) -> Option<usize> {
-        let c_path = CString::new(path.as_os_str().as_bytes()).ok()?;
-        let n = unsafe { libc::pathconf(c_path.as_ptr(), libc::_PC_PATH_MAX) };
-        (n > 0).then_some(n as usize)
     }
 
     fn cleanup(root_dir: &Dir, root: &Path) {

--- a/src/tests/recursive.rs
+++ b/src/tests/recursive.rs
@@ -253,6 +253,318 @@ fn nested() {
 }
 
 #[test]
+#[cfg(unix)]
+fn nested_beyond_path_max() {
+    let tree = match long_path::LongTree::create() {
+        Ok(Some(tree)) => tree,
+        Ok(None) => return,
+        Err(err) => panic!("failed to create long-path fixture: {}", err),
+    };
+
+    assert_walk_visits_long_leaf(WalkDir::new(tree.walk_root()), &tree);
+}
+
+#[test]
+#[cfg(unix)]
+fn nested_beyond_path_max_with_small_max_open() {
+    let tree = match long_path::LongTree::create() {
+        Ok(Some(tree)) => tree,
+        Ok(None) => return,
+        Err(err) => panic!("failed to create long-path fixture: {}", err),
+    };
+
+    assert_walk_visits_long_leaf(
+        WalkDir::new(tree.walk_root()).max_open(1),
+        &tree,
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn nested_beyond_path_max_follow_link() {
+    let tree = match long_path::LongTree::create_with_link() {
+        Ok(Some(tree)) => tree,
+        Ok(None) => return,
+        Err(err) => panic!("failed to create long-path fixture: {}", err),
+    };
+
+    let wd = WalkDir::new(tree.walk_root()).follow_links(true);
+    assert_walk_follows_long_link(wd, &tree);
+}
+
+#[test]
+#[cfg(unix)]
+fn nested_beyond_path_max_follow_link_same_file_system() {
+    let tree = match long_path::LongTree::create_with_link() {
+        Ok(Some(tree)) => tree,
+        Ok(None) => return,
+        Err(err) => panic!("failed to create long-path fixture: {}", err),
+    };
+
+    let wd = WalkDir::new(tree.walk_root())
+        .follow_links(true)
+        .same_file_system(true);
+    assert_walk_follows_long_link(wd, &tree);
+}
+
+#[test]
+#[cfg(unix)]
+fn nested_beyond_path_max_nofollow_link() {
+    let tree = match long_path::LongTree::create_with_link() {
+        Ok(Some(tree)) => tree,
+        Ok(None) => return,
+        Err(err) => panic!("failed to create long-path fixture: {}", err),
+    };
+
+    assert_walk_does_not_follow_long_link(
+        WalkDir::new(tree.walk_root()),
+        &tree,
+    );
+}
+
+#[cfg(unix)]
+fn assert_walk_visits_long_leaf(wd: WalkDir, tree: &long_path::LongTree) {
+    use std::ffi::OsStr;
+
+    let mut ents = vec![];
+    let mut errs = vec![];
+    for result in wd {
+        match result {
+            Ok(ent) => ents.push(ent),
+            Err(err) => errs.push(err),
+        }
+    }
+
+    assert!(errs.is_empty(), "expected no traversal errors: {:?}", errs);
+    let leaf = ents
+        .iter()
+        .find(|ent| ent.file_name() == OsStr::new(long_path::LEAF))
+        .expect("expected to visit sentinel leaf beyond PATH_MAX");
+
+    assert!(
+        long_path::byte_len(leaf.path()) > tree.path_max(),
+        "sentinel path should exceed PATH_MAX"
+    );
+    assert_eq!(tree.leaf_depth(), leaf.depth());
+    assert!(leaf.file_type().is_file());
+    assert_eq!(0, leaf.metadata().expect("metadata").len());
+}
+
+#[cfg(unix)]
+fn assert_walk_follows_long_link(wd: WalkDir, tree: &long_path::LongTree) {
+    use std::ffi::OsStr;
+
+    let mut ents = vec![];
+    let mut errs = vec![];
+    for result in wd {
+        match result {
+            Ok(ent) => ents.push(ent),
+            Err(err) => errs.push(err),
+        }
+    }
+
+    assert!(errs.is_empty(), "expected no traversal errors: {:?}", errs);
+
+    let link = ents
+        .iter()
+        .find(|ent| ent.file_name() == OsStr::new(long_path::LINK_DIR))
+        .expect("expected to visit symlink directory beyond PATH_MAX");
+    assert!(link.path_is_symlink());
+    assert!(link.file_type().is_dir());
+    assert_eq!(tree.link_depth(), link.depth());
+    assert!(
+        long_path::byte_len(link.path()) > tree.path_max(),
+        "symlink directory path should exceed PATH_MAX"
+    );
+
+    let leaf = ents
+        .iter()
+        .find(|ent| {
+            ent.file_name() == OsStr::new(long_path::LINK_LEAF)
+                && ent.path().parent().and_then(|p| p.file_name())
+                    == Some(OsStr::new(long_path::LINK_DIR))
+        })
+        .expect("expected to visit leaf through symlink beyond PATH_MAX");
+    assert_eq!(tree.link_depth() + 1, leaf.depth());
+    assert!(leaf.file_type().is_file());
+    assert_eq!(0, leaf.metadata().expect("metadata").len());
+}
+
+#[cfg(unix)]
+fn assert_walk_does_not_follow_long_link(
+    wd: WalkDir,
+    tree: &long_path::LongTree,
+) {
+    use std::ffi::OsStr;
+
+    let mut ents = vec![];
+    let mut errs = vec![];
+    for result in wd {
+        match result {
+            Ok(ent) => ents.push(ent),
+            Err(err) => errs.push(err),
+        }
+    }
+
+    assert!(errs.is_empty(), "expected no traversal errors: {:?}", errs);
+
+    let link = ents
+        .iter()
+        .find(|ent| ent.file_name() == OsStr::new(long_path::LINK_DIR))
+        .expect("expected to visit symlink directory beyond PATH_MAX");
+    assert!(link.path_is_symlink());
+    assert!(link.file_type().is_symlink());
+    assert!(link.metadata().expect("metadata").file_type().is_symlink());
+    assert_eq!(tree.link_depth(), link.depth());
+    assert!(
+        long_path::byte_len(link.path()) > tree.path_max(),
+        "symlink directory path should exceed PATH_MAX"
+    );
+
+    assert!(
+        !ents.iter().any(|ent| {
+            ent.file_name() == OsStr::new(long_path::LINK_LEAF)
+                && ent.path().parent().and_then(|p| p.file_name())
+                    == Some(OsStr::new(long_path::LINK_DIR))
+        }),
+        "unfollowed symlink should not be descended into",
+    );
+}
+
+#[cfg(unix)]
+mod long_path {
+    use std::ffi::CString;
+    use std::fs;
+    use std::io;
+    use std::os::unix::ffi::OsStrExt;
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use cap_std::{ambient_authority, fs::Dir};
+
+    pub const LEAF: &str = "needle.txt";
+    pub const LINK_DIR: &str = "link-dir";
+    pub const LINK_LEAF: &str = "link-needle.txt";
+    const LINK_TARGET: &str = "link-target";
+
+    static NEXT: AtomicUsize = AtomicUsize::new(0);
+
+    pub struct LongTree {
+        root: PathBuf,
+        walk_root: PathBuf,
+        path_max: usize,
+        depth: usize,
+        root_dir: Option<Dir>,
+    }
+
+    impl LongTree {
+        pub fn create() -> io::Result<Option<LongTree>> {
+            Self::create_imp(false)
+        }
+
+        pub fn create_with_link() -> io::Result<Option<LongTree>> {
+            Self::create_imp(true)
+        }
+
+        fn create_imp(with_link: bool) -> io::Result<Option<LongTree>> {
+            let root =
+                std::env::temp_dir().join("walkdir-long-path").join(format!(
+                    "{}-{}",
+                    std::process::id(),
+                    NEXT.fetch_add(1, Ordering::Relaxed)
+                ));
+
+            fs::create_dir_all(&root)?;
+            let root_dir = Dir::open_ambient_dir(&root, ambient_authority())?;
+            let path_max = path_max(&root).unwrap_or(4096);
+
+            let _ = root_dir.remove_dir_all("tree");
+            root_dir.create_dir("tree")?;
+            let mut cur = root_dir.open_dir("tree")?;
+            let mut rel = PathBuf::from("tree");
+            let component = "d".repeat(64);
+            let mut depth = 0;
+
+            while byte_len(&root.join(&rel))
+                <= path_max + component.len() + LEAF.len()
+            {
+                if let Err(err) = cur.create_dir(&component) {
+                    cleanup(&root_dir, &root);
+                    return if byte_len(&root.join(&rel)) > path_max {
+                        Ok(None)
+                    } else {
+                        Err(err)
+                    };
+                }
+                cur = cur.open_dir(&component)?;
+                rel.push(&component);
+                depth += 1;
+            }
+
+            cur.create(LEAF)?;
+            if with_link {
+                cur.create_dir(LINK_TARGET)?;
+                cur.open_dir(LINK_TARGET)?.create(LINK_LEAF)?;
+                cur.symlink(LINK_TARGET, LINK_DIR)?;
+            }
+
+            let walk_root = root_dir_path(&root);
+            Ok(Some(LongTree {
+                root,
+                walk_root,
+                path_max,
+                depth,
+                root_dir: Some(root_dir),
+            }))
+        }
+
+        pub fn walk_root(&self) -> &Path {
+            &self.walk_root
+        }
+
+        pub fn path_max(&self) -> usize {
+            self.path_max
+        }
+
+        pub fn leaf_depth(&self) -> usize {
+            self.depth + 1
+        }
+
+        pub fn link_depth(&self) -> usize {
+            self.depth + 1
+        }
+    }
+
+    impl Drop for LongTree {
+        fn drop(&mut self) {
+            if let Some(root_dir) = self.root_dir.take() {
+                let _ = root_dir.remove_dir_all("tree");
+            }
+            let _ = fs::remove_dir_all(&self.root);
+        }
+    }
+
+    pub fn byte_len(path: &Path) -> usize {
+        path.as_os_str().as_bytes().len()
+    }
+
+    fn root_dir_path(root: &Path) -> PathBuf {
+        root.join("tree")
+    }
+
+    fn path_max(path: &Path) -> Option<usize> {
+        let c_path = CString::new(path.as_os_str().as_bytes()).ok()?;
+        let n = unsafe { libc::pathconf(c_path.as_ptr(), libc::_PC_PATH_MAX) };
+        (n > 0).then_some(n as usize)
+    }
+
+    fn cleanup(root_dir: &Dir, root: &Path) {
+        let _ = root_dir.remove_dir_all("tree");
+        let _ = fs::remove_dir_all(root);
+    }
+}
+
+#[test]
 fn nested_small_max_open() {
     let nested =
         PathBuf::from("a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/t/u/v/w/x/y/z");

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,4 @@
+use std::fs;
 use std::io;
 use std::path::Path;
 
@@ -8,6 +9,13 @@ pub fn device_num<P: AsRef<Path>>(path: P) -> io::Result<u64> {
     path.as_ref().metadata().map(|md| md.dev())
 }
 
+#[cfg(unix)]
+pub fn device_num_from_metadata(md: &fs::Metadata) -> io::Result<u64> {
+    use std::os::unix::fs::MetadataExt;
+
+    Ok(md.dev())
+}
+
 #[cfg(windows)]
 pub fn device_num<P: AsRef<Path>>(path: P) -> io::Result<u64> {
     use winapi_util::{file, Handle};
@@ -16,8 +24,23 @@ pub fn device_num<P: AsRef<Path>>(path: P) -> io::Result<u64> {
     file::information(h).map(|info| info.volume_serial_number())
 }
 
+#[cfg(windows)]
+pub fn device_num_from_metadata(md: &fs::Metadata) -> io::Result<u64> {
+    use std::os::windows::fs::MetadataExt;
+
+    Ok(md.volume_serial_number().unwrap_or(0))
+}
+
 #[cfg(not(any(unix, windows)))]
 pub fn device_num<P: AsRef<Path>>(_: P) -> io::Result<u64> {
+    Err(io::Error::new(
+        io::ErrorKind::Other,
+        "walkdir: same_file_system option not supported on this platform",
+    ))
+}
+
+#[cfg(not(any(unix, windows)))]
+pub fn device_num_from_metadata(_: &fs::Metadata) -> io::Result<u64> {
     Err(io::Error::new(
         io::ErrorKind::Other,
         "walkdir: same_file_system option not supported on this platform",

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,8 @@
-use std::fs;
 use std::io;
 use std::path::Path;
+
+#[cfg(not(windows))]
+use std::fs;
 
 #[cfg(unix)]
 pub fn device_num<P: AsRef<Path>>(path: P) -> io::Result<u64> {
@@ -22,13 +24,6 @@ pub fn device_num<P: AsRef<Path>>(path: P) -> io::Result<u64> {
 
     let h = Handle::from_path_any(path)?;
     file::information(h).map(|info| info.volume_serial_number())
-}
-
-#[cfg(windows)]
-pub fn device_num_from_metadata(md: &fs::Metadata) -> io::Result<u64> {
-    use std::os::windows::fs::MetadataExt;
-
-    Ok(md.volume_serial_number().unwrap_or(0))
 }
 
 #[cfg(not(any(unix, windows)))]


### PR DESCRIPTION
Fixes descriptor/path-length failures seen downstream in sharkdp/fd#1985.

This teaches walkdir to keep traversal working after ambient path strings exceed `PATH_MAX` by using descriptor/capability-relative directory access for descendants instead of repeatedly reopening/stating full paths.

### What changed

- Add Unix cap-relative traversal for deep descendants.
- Avoid retaining open child directory handles on yielded/buffered entries, so `max_open` behavior remains bounded.
- Preserve root-relative paths for descriptor traversal.
- Use cached/descriptor-derived metadata for `same_file_system`.
- Handle `follow_links(true)` for symlinked directories beyond `PATH_MAX`.
- Preserve symlink public behavior for unfollowed long symlinks:
  - `path_is_symlink()`
  - `file_type().is_symlink()`
  - `metadata().file_type().is_symlink()`

### Validation

Added Unix regression coverage for:

- deep directory traversal beyond `PATH_MAX`
- traversal with `max_open(1)`
- followed symlink directories beyond `PATH_MAX`
- followed symlink directories with `same_file_system(true)`
- unfollowed symlinks beyond `PATH_MAX`

Local checks:

```sh
cargo fmt --check
cargo check -p walkdir
cargo build --verbose
cargo doc --verbose
cargo test -p walkdir
rm -f Cargo.lock && cargo +1.60.0 test -p walkdir
rm -f Cargo.lock && cargo check --target x86_64-pc-windows-msvc
rm -f Cargo.lock && cargo check --target x86_64-pc-windows-gnu
rm -f Cargo.lock && cargo +1.60.0 check --target x86_64-pc-windows-msvc
rm -f Cargo.lock && cargo +nightly generate-lockfile -Z minimal-versions && cargo +nightly build --verbose && cargo +nightly test --verbose
rm -f Cargo.lock && cargo tree -p walkdir --target x86_64-pc-windows-msvc
```

The Windows target tree contains only `same-file`/`winapi-util` and does not pull in `cap-std`, `cap-primitives`, `rustix`, `fs-set-times`, `io-lifetimes`, or `windows-link`.

### Dependency notes

This uses `cap-std` 1.x on Unix only so the patch can keep walkdir's advertised Rust 1.60 floor while avoiding `cap-primitives` on Windows Rust 1.60, where its Windows `io_safety` APIs are too new. Because walkdir does not commit `Cargo.lock`, the manifest includes a few narrow Unix patch pins to keep lockfile-less Rust 1.60 and nightly minimal-version CI from resolving transitive patch releases whose MSRV has since moved above 1.60.

Downstream sequencing:

1. land/release this walkdir fix
2. update ripgrep/ignore traversal
3. bump fd's ignore dependency and keep the fd traversal-error exit-status fix
