### PR TITLE
docs: update stale references to fs::DirEntry and note descriptor behavior (#167)

### DIFF
--- a/src/dent.rs
+++ b/src/dent.rs
@@ -26,6 +26,8 @@ use crate::Result;
 /// * If [`follow_links`] was enabled on the originating iterator, then all
 /// operations except for [`path`] operate on the link target. Otherwise, all
 /// operations operate on the symbolic link.
+/// * Unlike `std::fs::DirEntry` on some platforms, `walkdir::DirEntry` does not
+/// hold an open directory file descriptor or handle.
 ///
 /// [`std::fs`]: https://doc.rust-lang.org/stable/std/fs/index.html
 /// [`path`]: #method.path

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -573,7 +573,7 @@ pub struct IntoIter {
     start: Option<PathBuf>,
     /// A stack of open (up to max fd) or closed handles to directories.
     /// An open handle is a plain [`fs::ReadDir`] while a closed handle is
-    /// a `Vec<fs::DirEntry>` corresponding to the as-of-yet consumed entries.
+    /// a list of `Result<DirEntry>` corresponding to the as-of-yet consumed entries.
     ///
     /// [`fs::ReadDir`]: https://doc.rust-lang.org/stable/std/fs/struct.ReadDir.html
     stack_list: Vec<DirList>,
@@ -653,10 +653,9 @@ impl Ancestor {
 /// This represents the opened or closed state of a directory handle. When
 /// open, future entries are read by iterating over the raw `fs::ReadDir`.
 /// When closed, all future entries are read into memory. Iteration then
-/// proceeds over a [`Vec<fs::DirEntry>`].
+/// proceeds over the remaining `Result<DirEntry>` values.
 ///
 /// [`fs::ReadDir`]: https://doc.rust-lang.org/stable/std/fs/struct.ReadDir.html
-/// [`Vec<fs::DirEntry>`]: https://doc.rust-lang.org/stable/std/vec/struct.Vec.html
 #[derive(Debug)]
 enum DirList {
     /// An opened handle.


### PR DESCRIPTION
## Description

Resolves #167.

This PR addresses two documentation inaccuracies / omissions regarding `DirEntry`:

1. Updates comments on `IntoIter::stack_list` and `DirList` that described closed directory handles as reading into a `Vec<fs::DirEntry>`. The internal representation yields `Result<walkdir::DirEntry>`, not `std::fs::DirEntry`.
2. Adds a clarifying note under `# Differences with std::fs::DirEntry` in `src/dent.rs` noting that unlike `std::fs::DirEntry` on some platforms which retains an open directory handle/file descriptor, `walkdir::DirEntry` does not retain an open descriptor.

## Verification

- `cargo test`: 47 unit tests passed, 20 doc-tests passed.
- `cargo doc --no-deps`: documentation rendered cleanly without warnings.